### PR TITLE
feat(parser): add plugin-based parser strategies with ruamel-yaml support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         run: uv sync
       - name: Ruff + Pyright
         run: |
-          uv run ruff --output-format=github .
+          uv run ruff check --output-format=github .
           uv run ruff format --check .
           uv run pyright
 

--- a/packages/jentic-openapi-parser/pyproject.toml
+++ b/packages/jentic-openapi-parser/pyproject.toml
@@ -6,7 +6,9 @@ readme = "README.md"
 authors = [{ name = "Jentic", email = "hello@jentic.com" }]
 license = { text = "Apache-2.0" }
 requires-python = ">=3.11"
-dependencies = []
+dependencies = [
+    "ruamel-yaml"
+]
 
 [project.urls]
 Homepage = "https://github.com/jentic/jentic-openapi-tools"

--- a/packages/jentic-openapi-parser/src/jentic_openapi_parser/__init__.py
+++ b/packages/jentic-openapi-parser/src/jentic_openapi_parser/__init__.py
@@ -1,4 +1,4 @@
 from .openapi_parser import OpenAPIParser
-from .uri import is_uri_like, resolve_to_absolute, UriResolutionError
+from .uri import is_uri_like, load_uri, resolve_to_absolute, UriResolutionError
 
-__all__ = ["OpenAPIParser", "is_uri_like", "resolve_to_absolute", "UriResolutionError"]
+__all__ = ["OpenAPIParser", "is_uri_like", "load_uri", "resolve_to_absolute", "UriResolutionError"]

--- a/packages/jentic-openapi-parser/src/jentic_openapi_parser/openapi_parser.py
+++ b/packages/jentic-openapi-parser/src/jentic_openapi_parser/openapi_parser.py
@@ -1,52 +1,136 @@
-from typing import Any, Mapping, Optional
-import requests
-import yaml
-import json
+import importlib.metadata
+from typing import Any, TypeVar, cast, Optional, overload, Mapping, Sequence
 
-from .uri import is_uri_like, resolve_to_absolute
+from .uri import is_uri_like, load_uri
+from .strategies.base import BaseParserStrategy
+from .strategies.default_strategy import DefaultOpenAPIParser
+from .strategies.ruamel_strategy import RuamelOpenAPIParser
+from .strategies.ruamel_roundtrip_strategy import RuamelRoundTripOpenAPIParser
+
+T = TypeVar("T")
 
 
 class OpenAPIParser:
-    def is_uri_like(self, s: Optional[str]) -> bool:
+    """
+    Provides a parser for OpenAPI specifications using customizable strategies.
+
+    This class is designed to facilitate the parsing of OpenAPI documents.
+    It supports multiple strategies and can be extended through plugins.
+    When multiple strategies are used, the returned value is the result from the last strategy of the list that succeeds.
+    This mechanism is designed to allow passing multiple strategies to the parser and concur to the validation process
+    by reporting the errors and success status from all strategies.
+
+    Attributes:
+        strategies (list[BaseParserStrategy]): List of strategies used by the parser,
+        each implementing the BaseParserStrategy interface.
+    """
+
+    def __init__(self, strategies: list | None = None):
+        # If no strategies specified, use default
+        if not strategies:
+            strategies = ["default"]
+        self.strategies = []  # list of BaseParserStrategy instances
+
+        # Discover entry points for parser plugins
+        # (This could be a one-time load stored at class level to avoid doing it every time)
+        eps = importlib.metadata.entry_points(group="jentic.openapi_parser_strategies")
+        plugin_map = {ep.name: ep for ep in eps}
+
+        for strat in strategies:
+            if isinstance(strat, str):
+                name = strat
+                if name == "default":
+                    # Use built-in default parser
+                    self.strategies.append(DefaultOpenAPIParser())
+                elif name == "ruamel":
+                    # Use built-in ruamel parser
+                    self.strategies.append(RuamelOpenAPIParser())
+                elif name == "ruamel-rt":
+                    # Use built-in ruamel roundtrip parser
+                    self.strategies.append(RuamelRoundTripOpenAPIParser())
+                elif name in plugin_map:
+                    plugin_class = plugin_map[name].load()  # loads the class
+                    self.strategies.append(plugin_class())
+                else:
+                    raise ValueError(f"No parser plugin named '{name}' found")
+            elif isinstance(strat, BaseParserStrategy):
+                self.strategies.append(strat)
+            elif hasattr(strat, "__call__") and issubclass(strat, BaseParserStrategy):
+                # if a class (not instance) is passed
+                self.strategies.append(strat())
+            else:
+                raise TypeError("Invalid strategy type: must be name or strategy class/instance")
+
+    @overload
+    def parse(self, source: str) -> dict[str, Any]: ...
+
+    @overload
+    def parse(self, source: str, *, return_type: type[T], strict: bool = False) -> T: ...
+
+    def parse(
+        self, source: str, *, return_type: type[T] | None = None, strict: bool = False
+    ) -> Any:
+        raw = self._parse(source)
+
+        if return_type is None:
+            return self._to_plain(raw)
+
+        if strict:
+            if not isinstance(raw, return_type):
+                raise TypeError(
+                    f"Expected {getattr(return_type, '__name__', return_type)}, "
+                    f"got {type(raw).__name__}"
+                )
+        return cast(T, raw)
+
+    def _parse(self, source: str) -> Any:
+        text = source
+        is_uri = is_uri_like(source)
+        result = None
+        if is_uri and self.has_non_uri_strategy():
+            text = self.load_uri(source)
+        for strat in self.strategies:
+            document = None
+            if is_uri and "uri" in strat.accepts():
+                document = source
+            elif is_uri and "text" in strat.accepts():
+                document = text
+            elif not is_uri and "text" in strat.accepts():
+                document = text
+
+            if document is not None:
+                try:
+                    result = strat.parse(document)
+                except Exception as e:
+                    # TODO add to parser/validation chain result
+                    print(f"Error parsing document: {e}")
+        if result is None:
+            raise ValueError("No valid document found")
+        return result
+
+    def has_non_uri_strategy(self) -> bool:
+        """Check if any strategy accepts 'text' but not 'uri'."""
+        for strat in self.strategies:
+            accepted = strat.accepts()
+            if "text" in accepted and "uri" not in accepted:
+                return True
+        return False
+
+    def _to_plain(self, obj: Any) -> Any:
+        # Mapping?
+        if isinstance(obj, Mapping):
+            return {k: self._to_plain(v) for k, v in obj.items()}
+
+        # Sequence but NOT str/bytes
+        if isinstance(obj, Sequence) and not isinstance(obj, (str, bytes, bytearray)):
+            return [self._to_plain(x) for x in obj]
+
+        # Scalar
+        return obj
+
+    @staticmethod
+    def is_uri_like(s: Optional[str]) -> bool:
         return is_uri_like(s)
 
     def load_uri(self, uri: str) -> str:
-        resolved_uri = resolve_to_absolute(uri)
-
-        if resolved_uri.startswith("http://") or uri.startswith("https://"):
-            content = requests.get(resolved_uri).text
-        elif resolved_uri.startswith("file://"):
-            with open(resolved_uri, "r", encoding="utf-8") as f:
-                content = f.read()
-        else:
-            # Treat as local file path
-            with open(resolved_uri, "r", encoding="utf-8") as f:
-                content = f.read()
-        return content
-
-    def parse(self, source: str) -> dict[str, Any]:
-        text = source
-        try:
-            if is_uri_like(source):
-                text = self.load_uri(source)
-
-            data = self.parse_text(text)
-        except Exception:
-            msg = f"Unsupported document type: {type(source)!r}"
-            raise TypeError(msg)
-        return data
-
-    def parse_uri(self, uri: str) -> dict[str, Any]:
-        return self.parse_text(self.load_uri(uri))
-
-    def parse_text(self, text: str) -> dict[str, Any]:
-        try:
-            data = yaml.safe_load(text)
-        except Exception:
-            if isinstance(text, (bytes, str)):
-                text = text.decode() if isinstance(text, bytes) else text
-                data = json.loads(text)
-        if isinstance(data, Mapping):
-            return dict(data)
-        msg = f"Unsupported document type: {type(text)!r}"
-        raise TypeError(msg)
+        return load_uri(uri)

--- a/packages/jentic-openapi-parser/src/jentic_openapi_parser/strategies/base.py
+++ b/packages/jentic-openapi-parser/src/jentic_openapi_parser/strategies/base.py
@@ -1,0 +1,16 @@
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class BaseParserStrategy(ABC):
+    """Interface that all Parser plugins must implement."""
+
+    @abstractmethod
+    def parse(self, source: str) -> Any:
+        """Parses an OpenAPI document given by URI or file path or text.
+        Returns a dict."""
+        pass
+
+    @abstractmethod
+    def accepts(self) -> list[str]:
+        pass

--- a/packages/jentic-openapi-parser/src/jentic_openapi_parser/strategies/default_strategy.py
+++ b/packages/jentic-openapi-parser/src/jentic_openapi_parser/strategies/default_strategy.py
@@ -1,0 +1,37 @@
+from typing import Any, Mapping
+import yaml
+import json
+from .base import BaseParserStrategy
+from ..uri import is_uri_like, load_uri
+
+
+class DefaultOpenAPIParser(BaseParserStrategy):
+    def parse(self, source: str) -> Any:
+        text = source
+        try:
+            if is_uri_like(source):
+                text = load_uri(source)
+
+            data = self.parse_text(text)
+        except Exception:
+            msg = f"Unsupported document type: {type(source)!r}"
+            raise TypeError(msg)
+        return data
+
+    def parse_uri(self, uri: str) -> Any:
+        return self.parse_text(load_uri(uri))
+
+    def parse_text(self, text: str) -> Any:
+        try:
+            data = yaml.safe_load(text)
+        except Exception:
+            if isinstance(text, (bytes, str)):
+                text = text.decode() if isinstance(text, bytes) else text
+                data = json.loads(text)
+        if isinstance(data, Mapping):
+            return dict(data)
+        msg = f"Unsupported document type: {type(text)!r}"
+        raise TypeError(msg)
+
+    def accepts(self) -> list[str]:
+        return ["uri", "text"]

--- a/packages/jentic-openapi-parser/src/jentic_openapi_parser/strategies/ruamel_roundtrip_strategy.py
+++ b/packages/jentic-openapi-parser/src/jentic_openapi_parser/strategies/ruamel_roundtrip_strategy.py
@@ -1,0 +1,6 @@
+from .ruamel_strategy import RuamelOpenAPIParser
+
+
+class RuamelRoundTripOpenAPIParser(RuamelOpenAPIParser):
+    def __init__(self, pure: bool = True):
+        super().__init__(typ="rt", pure=pure)

--- a/packages/jentic-openapi-parser/src/jentic_openapi_parser/strategies/ruamel_strategy.py
+++ b/packages/jentic-openapi-parser/src/jentic_openapi_parser/strategies/ruamel_strategy.py
@@ -1,0 +1,41 @@
+from typing import Any, Mapping
+from ruamel.yaml import YAML
+import json
+from .base import BaseParserStrategy
+from ..uri import is_uri_like, load_uri
+
+
+class RuamelOpenAPIParser(BaseParserStrategy):
+    def __init__(self, typ: str = "safe", pure: bool = True):
+        self.yaml = YAML(typ=typ, pure=pure)
+        self.yaml.default_flow_style = False
+
+    def parse(self, source: str) -> Any:
+        text = source
+        try:
+            if is_uri_like(source):
+                text = load_uri(source)
+
+            data = self.parse_text(text)
+        except Exception:
+            msg = f"Unsupported document type: {type(source)!r}"
+            raise TypeError(msg)
+        return data
+
+    def parse_uri(self, uri: str) -> Any:
+        return self.parse_text(load_uri(uri))
+
+    def parse_text(self, text: str) -> Any:
+        try:
+            data = self.yaml.load(text)
+        except Exception:
+            if isinstance(text, (bytes, str)):
+                text = text.decode() if isinstance(text, bytes) else text
+                data = json.loads(text)
+        if isinstance(data, Mapping):
+            return data
+        msg = f"Unsupported document type: {type(text)!r}"
+        raise TypeError(msg)
+
+    def accepts(self) -> list[str]:
+        return ["uri", "text"]

--- a/packages/jentic-openapi-parser/src/jentic_openapi_parser/uri.py
+++ b/packages/jentic-openapi-parser/src/jentic_openapi_parser/uri.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import os
 import re
 import urllib.request
+import requests
 
 _WINDOWS_DRIVE_RE = re.compile(r"^[A-Za-z]:[\\/]")
 _WINDOWS_UNC_RE = re.compile(r"^(?:\\\\|//)[^\\/]+[\\/][^\\/]+")
@@ -180,3 +181,18 @@ def _resolve_path_like(value: str, base_uri: Optional[str]) -> str:
 
     p = Path(value)
     return str(p.resolve() if p.is_absolute() else (base_path / p).resolve())
+
+
+def load_uri(uri: str) -> str:
+    resolved_uri = resolve_to_absolute(uri)
+
+    if resolved_uri.startswith("http://") or uri.startswith("https://"):
+        content = requests.get(resolved_uri).text
+    elif resolved_uri.startswith("file://"):
+        with open(resolved_uri, "r", encoding="utf-8") as f:
+            content = f.read()
+    else:
+        # Treat as local file path
+        with open(resolved_uri, "r", encoding="utf-8") as f:
+            content = f.read()
+    return content

--- a/packages/jentic-openapi-parser/tests/test_parse.py
+++ b/packages/jentic-openapi-parser/tests/test_parse.py
@@ -1,6 +1,9 @@
 from pathlib import Path
 
+import pytest
+
 from jentic_openapi_parser import OpenAPIParser
+from ruamel.yaml import CommentedMap
 
 # Get the fixtures directory
 FIXTURES_DIR = Path(__file__).parent / "fixtures" / "openapi"
@@ -21,3 +24,83 @@ def test_parse_json_string():
     doc = parser.parse('{"openapi":"3.1.0","info":{"title":"x","version":"1.0.0"}}')
     assert doc["openapi"] == "3.1.0"
     assert doc["info"]["title"] == "x"
+
+
+def test_parse_default_strategy():
+    """Test that the strategy mechanism works."""
+    parser = OpenAPIParser(["default"])
+    assert len(parser.strategies) == 1
+
+    # Verify the strategy types
+    strategy_names = [type(s).__name__ for s in parser.strategies]
+    assert "DefaultOpenAPIParser" in strategy_names
+    doc = parser.parse('{"openapi":"3.1.0","info":{"title":"x","version":"1.0.0"}}')
+    assert doc["openapi"] == "3.1.0"
+    assert doc["info"]["title"] == "x"
+
+
+def test_parse_ruamel_strategy():
+    """Test ruamel parser."""
+    parser = OpenAPIParser(["ruamel"])
+    assert len(parser.strategies) == 1
+    strategy_names = [type(s).__name__ for s in parser.strategies]
+    assert "RuamelOpenAPIParser" in strategy_names
+
+    doc = parser.parse('{"openapi":"3.1.0","info":{"title":"x","version":"1.0.0"}}')
+    assert doc["openapi"] == "3.1.0"
+    assert doc["info"]["title"] == "x"
+    assert not hasattr(doc, "lc")  # ruamel safe doesn't keep line/col info
+
+
+def test_parse_ruamel_roundtrip_strategy():
+    """Test ruamel-rt parser."""
+    parser = OpenAPIParser(["ruamel-rt"])
+    assert len(parser.strategies) == 1
+    strategy_names = [type(s).__name__ for s in parser.strategies]
+    assert "RuamelRoundTripOpenAPIParser" in strategy_names
+
+    doc = parser.parse(
+        '{"openapi":"3.1.0","info":{"title":"x","version":"1.0.0"}}', return_type=CommentedMap
+    )
+    assert doc["openapi"] == "3.1.0"
+    assert doc["info"]["title"] == "x"
+    assert hasattr(doc, "lc")  # ruamel roundtrip keeps line/col info
+
+
+def test_parse_default_and_ruamel_roundtrip_strategy():
+    """Test default and ruamel-rt parser."""
+    parser = OpenAPIParser(["default", "ruamel-rt"])
+    assert len(parser.strategies) == 2
+    strategy_names = [type(s).__name__ for s in parser.strategies]
+    assert "DefaultOpenAPIParser" in strategy_names
+    assert "RuamelRoundTripOpenAPIParser" in strategy_names
+
+    doc = parser.parse(
+        '{"openapi":"3.1.0","info":{"title":"x","version":"1.0.0"}}', return_type=CommentedMap
+    )
+    assert doc["openapi"] == "3.1.0"
+    assert doc["info"]["title"] == "x"
+    assert hasattr(doc, "lc")  # ruamel roundtrip keeps line/col info
+
+
+def test_parse_and_ruamel_roundtrip_and_default_strategy():
+    """Test ruamel-rt and default parser."""
+    parser = OpenAPIParser(["ruamel-rt", "default"])
+    assert len(parser.strategies) == 2
+    strategy_names = [type(s).__name__ for s in parser.strategies]
+    assert "DefaultOpenAPIParser" in strategy_names
+    assert "RuamelRoundTripOpenAPIParser" in strategy_names
+
+    doc = parser.parse(
+        '{"openapi":"3.1.0","info":{"title":"x","version":"1.0.0"}}', return_type=CommentedMap
+    )
+    assert doc["openapi"] == "3.1.0"
+    assert doc["info"]["title"] == "x"
+    assert not hasattr(doc, "lc")  # default strategy is last and returns a dict
+
+    with pytest.raises(TypeError):
+        doc = parser.parse(
+            '{"openapi":"3.1.0","info":{"title":"x","version":"1.0.0"}}',
+            return_type=CommentedMap,
+            strict=True,
+        )

--- a/packages/jentic-openapi-validator/src/jentic_openapi_validator/openapi_validator.py
+++ b/packages/jentic-openapi-validator/src/jentic_openapi_validator/openapi_validator.py
@@ -50,12 +50,12 @@ class OpenAPIValidator:
             is_text = not is_uri
 
             if is_text:
-                data = self.parser.parse_text(source)
+                data = self.parser.parse(source)
 
             if is_uri and self.has_non_uri_strategy():
                 text = self.parser.load_uri(source)
                 if not data:
-                    data = self.parser.parse_text(text)
+                    data = self.parser.parse(text)
         else:
             is_uri = False
             is_text = False

--- a/uv.lock
+++ b/uv.lock
@@ -249,6 +249,12 @@ wheels = [
 name = "jentic-openapi-parser"
 version = "0.1.0"
 source = { editable = "packages/jentic-openapi-parser" }
+dependencies = [
+    { name = "ruamel-yaml" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "ruamel-yaml" }]
 
 [[package]]
 name = "jentic-openapi-tools"
@@ -955,6 +961,53 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/24/e3e72d265121e00b063aef3e3501e5b2473cf1b23511d56e529531acf01e/rpds_py-0.27.1-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:94c44ee01fd21c9058f124d2d4f0c9dc7634bec93cd4b38eefc385dabe71acbf", size = 560003, upload-time = "2025-08-27T12:16:08.06Z" },
     { url = "https://files.pythonhosted.org/packages/26/ca/f5a344c534214cc2d41118c0699fffbdc2c1bc7046f2a2b9609765ab9c92/rpds_py-0.27.1-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:df8b74962e35c9249425d90144e721eed198e6555a0e22a563d29fe4486b51f6", size = 590482, upload-time = "2025-08-27T12:16:10.137Z" },
     { url = "https://files.pythonhosted.org/packages/ce/08/4349bdd5c64d9d193c360aa9db89adeee6f6682ab8825dca0a3f535f434f/rpds_py-0.27.1-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:dc23e6820e3b40847e2f4a7726462ba0cf53089512abe9ee16318c366494c17a", size = 556523, upload-time = "2025-08-27T12:16:12.188Z" },
+]
+
+[[package]]
+name = "ruamel-yaml"
+version = "0.18.15"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ruamel-yaml-clib", marker = "python_full_version < '3.14' and platform_python_implementation == 'CPython'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3e/db/f3950f5e5031b618aae9f423a39bf81a55c148aecd15a34527898e752cf4/ruamel.yaml-0.18.15.tar.gz", hash = "sha256:dbfca74b018c4c3fba0b9cc9ee33e53c371194a9000e694995e620490fd40700", size = 146865, upload-time = "2025-08-19T11:15:10.694Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/e5/f2a0621f1781b76a38194acae72f01e37b1941470407345b6e8653ad7640/ruamel.yaml-0.18.15-py3-none-any.whl", hash = "sha256:148f6488d698b7a5eded5ea793a025308b25eca97208181b6a026037f391f701", size = 119702, upload-time = "2025-08-19T11:15:07.696Z" },
+]
+
+[[package]]
+name = "ruamel-yaml-clib"
+version = "0.2.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/84/80203abff8ea4993a87d823a5f632e4d92831ef75d404c9fc78d0176d2b5/ruamel.yaml.clib-0.2.12.tar.gz", hash = "sha256:6c8fbb13ec503f99a91901ab46e0b07ae7941cd527393187039aec586fdfd36f", size = 225315, upload-time = "2024-10-20T10:10:56.22Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/8f/683c6ad562f558cbc4f7c029abcd9599148c51c54b5ef0f24f2638da9fbb/ruamel.yaml.clib-0.2.12-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:4a6679521a58256a90b0d89e03992c15144c5f3858f40d7c18886023d7943db6", size = 132224, upload-time = "2024-10-20T10:12:45.162Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/d2/b79b7d695e2f21da020bd44c782490578f300dd44f0a4c57a92575758a76/ruamel.yaml.clib-0.2.12-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:d84318609196d6bd6da0edfa25cedfbabd8dbde5140a0a23af29ad4b8f91fb1e", size = 641480, upload-time = "2024-10-20T10:12:46.758Z" },
+    { url = "https://files.pythonhosted.org/packages/68/6e/264c50ce2a31473a9fdbf4fa66ca9b2b17c7455b31ef585462343818bd6c/ruamel.yaml.clib-0.2.12-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bb43a269eb827806502c7c8efb7ae7e9e9d0573257a46e8e952f4d4caba4f31e", size = 739068, upload-time = "2024-10-20T10:12:48.605Z" },
+    { url = "https://files.pythonhosted.org/packages/86/29/88c2567bc893c84d88b4c48027367c3562ae69121d568e8a3f3a8d363f4d/ruamel.yaml.clib-0.2.12-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:811ea1594b8a0fb466172c384267a4e5e367298af6b228931f273b111f17ef52", size = 703012, upload-time = "2024-10-20T10:12:51.124Z" },
+    { url = "https://files.pythonhosted.org/packages/11/46/879763c619b5470820f0cd6ca97d134771e502776bc2b844d2adb6e37753/ruamel.yaml.clib-0.2.12-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:cf12567a7b565cbf65d438dec6cfbe2917d3c1bdddfce84a9930b7d35ea59642", size = 704352, upload-time = "2024-10-21T11:26:41.438Z" },
+    { url = "https://files.pythonhosted.org/packages/02/80/ece7e6034256a4186bbe50dee28cd032d816974941a6abf6a9d65e4228a7/ruamel.yaml.clib-0.2.12-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:7dd5adc8b930b12c8fc5b99e2d535a09889941aa0d0bd06f4749e9a9397c71d2", size = 737344, upload-time = "2024-10-21T11:26:43.62Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ca/e4106ac7e80efbabdf4bf91d3d32fc424e41418458251712f5672eada9ce/ruamel.yaml.clib-0.2.12-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1492a6051dab8d912fc2adeef0e8c72216b24d57bd896ea607cb90bb0c4981d3", size = 714498, upload-time = "2024-12-11T19:58:15.592Z" },
+    { url = "https://files.pythonhosted.org/packages/67/58/b1f60a1d591b771298ffa0428237afb092c7f29ae23bad93420b1eb10703/ruamel.yaml.clib-0.2.12-cp311-cp311-win32.whl", hash = "sha256:bd0a08f0bab19093c54e18a14a10b4322e1eacc5217056f3c063bd2f59853ce4", size = 100205, upload-time = "2024-10-20T10:12:52.865Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/4f/b52f634c9548a9291a70dfce26ca7ebce388235c93588a1068028ea23fcc/ruamel.yaml.clib-0.2.12-cp311-cp311-win_amd64.whl", hash = "sha256:a274fb2cb086c7a3dea4322ec27f4cb5cc4b6298adb583ab0e211a4682f241eb", size = 118185, upload-time = "2024-10-20T10:12:54.652Z" },
+    { url = "https://files.pythonhosted.org/packages/48/41/e7a405afbdc26af961678474a55373e1b323605a4f5e2ddd4a80ea80f628/ruamel.yaml.clib-0.2.12-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:20b0f8dc160ba83b6dcc0e256846e1a02d044e13f7ea74a3d1d56ede4e48c632", size = 133433, upload-time = "2024-10-20T10:12:55.657Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/b0/b850385604334c2ce90e3ee1013bd911aedf058a934905863a6ea95e9eb4/ruamel.yaml.clib-0.2.12-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:943f32bc9dedb3abff9879edc134901df92cfce2c3d5c9348f172f62eb2d771d", size = 647362, upload-time = "2024-10-20T10:12:57.155Z" },
+    { url = "https://files.pythonhosted.org/packages/44/d0/3f68a86e006448fb6c005aee66565b9eb89014a70c491d70c08de597f8e4/ruamel.yaml.clib-0.2.12-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95c3829bb364fdb8e0332c9931ecf57d9be3519241323c5274bd82f709cebc0c", size = 754118, upload-time = "2024-10-20T10:12:58.501Z" },
+    { url = "https://files.pythonhosted.org/packages/52/a9/d39f3c5ada0a3bb2870d7db41901125dbe2434fa4f12ca8c5b83a42d7c53/ruamel.yaml.clib-0.2.12-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:749c16fcc4a2b09f28843cda5a193e0283e47454b63ec4b81eaa2242f50e4ccd", size = 706497, upload-time = "2024-10-20T10:13:00.211Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/fa/097e38135dadd9ac25aecf2a54be17ddf6e4c23e43d538492a90ab3d71c6/ruamel.yaml.clib-0.2.12-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:bf165fef1f223beae7333275156ab2022cffe255dcc51c27f066b4370da81e31", size = 698042, upload-time = "2024-10-21T11:26:46.038Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/d5/a659ca6f503b9379b930f13bc6b130c9f176469b73b9834296822a83a132/ruamel.yaml.clib-0.2.12-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:32621c177bbf782ca5a18ba4d7af0f1082a3f6e517ac2a18b3974d4edf349680", size = 745831, upload-time = "2024-10-21T11:26:47.487Z" },
+    { url = "https://files.pythonhosted.org/packages/db/5d/36619b61ffa2429eeaefaab4f3374666adf36ad8ac6330d855848d7d36fd/ruamel.yaml.clib-0.2.12-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b82a7c94a498853aa0b272fd5bc67f29008da798d4f93a2f9f289feb8426a58d", size = 715692, upload-time = "2024-12-11T19:58:17.252Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/82/85cb92f15a4231c89b95dfe08b09eb6adca929ef7df7e17ab59902b6f589/ruamel.yaml.clib-0.2.12-cp312-cp312-win32.whl", hash = "sha256:e8c4ebfcfd57177b572e2040777b8abc537cdef58a2120e830124946aa9b42c5", size = 98777, upload-time = "2024-10-20T10:13:01.395Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/8f/c3654f6f1ddb75daf3922c3d8fc6005b1ab56671ad56ffb874d908bfa668/ruamel.yaml.clib-0.2.12-cp312-cp312-win_amd64.whl", hash = "sha256:0467c5965282c62203273b838ae77c0d29d7638c8a4e3a1c8bdd3602c10904e4", size = 115523, upload-time = "2024-10-20T10:13:02.768Z" },
+    { url = "https://files.pythonhosted.org/packages/29/00/4864119668d71a5fa45678f380b5923ff410701565821925c69780356ffa/ruamel.yaml.clib-0.2.12-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:4c8c5d82f50bb53986a5e02d1b3092b03622c02c2eb78e29bec33fd9593bae1a", size = 132011, upload-time = "2024-10-20T10:13:04.377Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/5e/212f473a93ae78c669ffa0cb051e3fee1139cb2d385d2ae1653d64281507/ruamel.yaml.clib-0.2.12-cp313-cp313-manylinux2014_aarch64.whl", hash = "sha256:e7e3736715fbf53e9be2a79eb4db68e4ed857017344d697e8b9749444ae57475", size = 642488, upload-time = "2024-10-20T10:13:05.906Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/8f/ecfbe2123ade605c49ef769788f79c38ddb1c8fa81e01f4dbf5cf1a44b16/ruamel.yaml.clib-0.2.12-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0b7e75b4965e1d4690e93021adfcecccbca7d61c7bddd8e22406ef2ff20d74ef", size = 745066, upload-time = "2024-10-20T10:13:07.26Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/a9/28f60726d29dfc01b8decdb385de4ced2ced9faeb37a847bd5cf26836815/ruamel.yaml.clib-0.2.12-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:96777d473c05ee3e5e3c3e999f5d23c6f4ec5b0c38c098b3a5229085f74236c6", size = 701785, upload-time = "2024-10-20T10:13:08.504Z" },
+    { url = "https://files.pythonhosted.org/packages/84/7e/8e7ec45920daa7f76046578e4f677a3215fe8f18ee30a9cb7627a19d9b4c/ruamel.yaml.clib-0.2.12-cp313-cp313-musllinux_1_1_i686.whl", hash = "sha256:3bc2a80e6420ca8b7d3590791e2dfc709c88ab9152c00eeb511c9875ce5778bf", size = 693017, upload-time = "2024-10-21T11:26:48.866Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b3/d650eaade4ca225f02a648321e1ab835b9d361c60d51150bac49063b83fa/ruamel.yaml.clib-0.2.12-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:e188d2699864c11c36cdfdada94d781fd5d6b0071cd9c427bceb08ad3d7c70e1", size = 741270, upload-time = "2024-10-21T11:26:50.213Z" },
+    { url = "https://files.pythonhosted.org/packages/87/b8/01c29b924dcbbed75cc45b30c30d565d763b9c4d540545a0eeecffb8f09c/ruamel.yaml.clib-0.2.12-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4f6f3eac23941b32afccc23081e1f50612bdbe4e982012ef4f5797986828cd01", size = 709059, upload-time = "2024-12-11T19:58:18.846Z" },
+    { url = "https://files.pythonhosted.org/packages/30/8c/ed73f047a73638257aa9377ad356bea4d96125b305c34a28766f4445cc0f/ruamel.yaml.clib-0.2.12-cp313-cp313-win32.whl", hash = "sha256:6442cb36270b3afb1b4951f060eccca1ce49f3d087ca1ca4563a6eb479cb3de6", size = 98583, upload-time = "2024-10-20T10:13:09.658Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/85/e8e751d8791564dd333d5d9a4eab0a7a115f7e349595417fd50ecae3395c/ruamel.yaml.clib-0.2.12-cp313-cp313-win_amd64.whl", hash = "sha256:e5b8daf27af0b90da7bb903a876477a9e6d7270be6146906b276605997c7e9a3", size = 115190, upload-time = "2024-10-20T10:13:10.66Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Add comprehensive plugin architecture for OpenAPI parsing with multiple strategy support:

- Add `BaseParserStrategy` interface for extensible parsing strategies
- Implement `DefaultOpenAPIParser`, `RuamelOpenAPIParser`, and `RuamelRoundTripOpenAPIParser` strategies
- Add plugin discovery system using `importlib.metadata` entry points
- Support multiple parser strategies with last-successful-wins semantics
- Add `ruamel-yaml` dependency for enhanced YAML parsing capabilities
- Enhance `OpenAPIParser` with overloaded parse method supporting custom return types
- Export `load_uri` function for external URI loading functionality

The parser now supports strategy-based parsing allowing users to choose between different parsing backends and enabling third-party extensions through the plugin system. This provides better flexibility for handling different YAML/JSON parsing requirements while maintaining backward compatibility.

BREAKING CHANGE: `OpenAPIParser` constructor now accepts strategies parameter, changing the default initialization behavior. The parse method signature has been enhanced with optional return_type and strict parameters.