### PR TITLE
feat(transformer): add Redocly bundling support with `jentic-openapi-bundler-redocly`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,8 @@ jobs:
         uses: astral-sh/setup-uv@v4
       - name: Set up Python
         run: uv python install ${{ matrix.python }}
+      - name: Install Redocly CLI
+        run: npm install -g @redocly/cli@latest
       - name: Install deps (with dev)
         run: uv sync
       - name: Pytest (transformer)
@@ -123,3 +125,26 @@ jobs:
         run: uv sync
       - name: Pytest (validator-spectral)
         run: uv run --package jentic-openapi-validator-spectral pytest -q packages/jentic-openapi-validator-spectral/tests
+
+  test_bundler_redocly:
+    name: Test (jentic-openapi-bundler-redocly)
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+      - name: Set up Python
+        run: uv python install ${{ matrix.python }}
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install Redocly CLI
+        run: npm install -g @redocly/cli@latest
+      - name: Install deps (with dev)
+        run: uv sync
+      - name: Pytest (bundler-redocly)
+        run: uv run --package jentic-openapi-bundler-redocly -q pytest packages/jentic-openapi-bundler-redocly/tests

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Install Spectral CLI
         run: npm install -g @stoplight/spectral-cli
 
+      - name: Install Redocly CLI
+        run: npm install -g @redocly/cli@latest
+
       - name: Install dependencies
         run: uv sync
 
@@ -48,6 +51,7 @@ jobs:
           uv run --package jentic-openapi-transformer pytest packages/jentic-openapi-transformer/tests -v
           uv run --package jentic-openapi-validator pytest packages/jentic-openapi-validator/tests -v
           uv run --package jentic-openapi-validator-spectral pytest packages/jentic-openapi-validator-spectral/tests -v
+          uv run --package jentic-openapi-bundler-redocly pytest packages/jentic-openapi-bundler-redocly/tests -v
 
       - name: Get next version for pre-release
         id: next_version
@@ -64,6 +68,7 @@ jobs:
           uv build --package jentic-openapi-transformer
           uv build --package jentic-openapi-validator
           uv build --package jentic-openapi-validator-spectral
+          uv build --package jentic-openapi-bundler-redocly
 
       - name: Create pre-release
         env:
@@ -85,3 +90,4 @@ jobs:
           uv publish --package jentic-openapi-transformer
           uv publish --package jentic-openapi-validator
           uv publish --package jentic-openapi-validator-spectral
+          uv publish --package jentic-openapi-bundler-redocly

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,9 @@ jobs:
       - name: Install Spectral CLI
         run: npm install -g @stoplight/spectral-cli
 
+      - name: Install Redocly CLI
+        run: npm install -g @redocly/cli@latest
+
       - name: Install dependencies
         run: uv sync
 
@@ -130,6 +133,7 @@ jobs:
           uv run --package jentic-openapi-transformer pytest packages/jentic-openapi-transformer/tests -v
           uv run --package jentic-openapi-validator pytest packages/jentic-openapi-validator/tests -v
           uv run --package jentic-openapi-validator-spectral pytest packages/jentic-openapi-validator-spectral/tests -v
+          uv run --package jentic-openapi-bundler-redocly pytest packages/jentic-openapi-bundler-redocly/tests -v
 
       - name: Simulate version bump (DRY RUN)
         if: steps.check_release.outputs.release_needed == 'true' && env.DRY_RUN == 'true'
@@ -141,6 +145,7 @@ jobs:
           echo "  - packages/jentic-openapi-transformer/pyproject.toml"  
           echo "  - packages/jentic-openapi-validator/pyproject.toml"
           echo "  - packages/jentic-openapi-validator-spectral/pyproject.toml"
+          echo "  - packages/jentic-openapi-bundler-redocly/pyproject.toml"
           echo "🔍 DRY RUN: Would create git tag: v${{ steps.version_info.outputs.next_version }}"
 
       - name: Handle first release (DRY RUN)
@@ -176,6 +181,7 @@ jobs:
           echo "- jentic-openapi-transformer ${CURRENT_VERSION}" >> CHANGELOG.md
           echo "- jentic-openapi-validator ${CURRENT_VERSION}" >> CHANGELOG.md
           echo "- jentic-openapi-validator-spectral ${CURRENT_VERSION}" >> CHANGELOG.md
+          echo "- jentic-openapi-bundler-redocly ${CURRENT_VERSION}" >> CHANGELOG.md
           echo "" >> CHANGELOG.md
           echo "### Features" >> CHANGELOG.md
           echo "- Initial release of Jentic OpenAPI Tools" >> CHANGELOG.md
@@ -209,6 +215,7 @@ jobs:
           uv build --package jentic-openapi-transformer
           uv build --package jentic-openapi-validator
           uv build --package jentic-openapi-validator-spectral
+          uv build --package jentic-openapi-bundler-redocly
 
       - name: Show build artifacts
         if: steps.check_release.outputs.release_needed == 'true'
@@ -231,6 +238,7 @@ jobs:
           echo "  - jentic-openapi-transformer"
           echo "  - jentic-openapi-validator"
           echo "  - jentic-openapi-validator-spectral"
+          echo "  - jentic-openapi-bundler-redocly"
 
       - name: Create GitHub Release (REAL)
         if: steps.check_release.outputs.release_needed == 'true' && env.DRY_RUN == 'false'
@@ -259,6 +267,7 @@ jobs:
           uv publish --package jentic-openapi-transformer
           uv publish --package jentic-openapi-validator
           uv publish --package jentic-openapi-validator-spectral
+          uv publish --package jentic-openapi-bundler-redocly
 
       - name: Release Summary (DRY RUN)
         if: steps.check_release.outputs.release_needed == 'true' && env.DRY_RUN == 'true'

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ uv run --package jentic-openapi-parser       pytest packages/jentic-openapi-pars
 uv run --package jentic-openapi-transformer  pytest packages/jentic-openapi-transformer/tests -q
 uv run --package jentic-openapi-validator    pytest packages/jentic-openapi-validator/tests -q
 uv run --package jentic-openapi-validator-spectral    pytest packages/jentic-openapi-validator-spectral/tests -q
+uv run --package jentic-openapi-bundler-redocly    pytest packages/jentic-openapi-bundler-redocly/tests -q
 ```
 
 ### Run linting
@@ -32,6 +33,7 @@ uv build --package jentic-openapi-parser
 uv build --package jentic-openapi-transformer
 uv build --package jentic-openapi-validator
 uv build --package jentic-openapi-validator-spectral
+uv build --package jentic-openapi-bundler-redocly
 ```
 
 ### Conventional Commits

--- a/packages/jentic-openapi-bundler-redocly/README.md
+++ b/packages/jentic-openapi-bundler-redocly/README.md
@@ -1,0 +1,18 @@
+# jentic-openapi-bundler-redocly
+
+## Running the tests
+To run these integration tests, you would need both packages installed. You can test this setup by:
+
+1. **Installing both packages in development mode:**
+
+```
+# From the project root
+uv run pip install -e packages/jentic-openapi-transformer
+uv run pip install -e packages/jentic-openapi-bundler-redocly
+```
+
+2. **Running the integration test:**
+
+```
+uv run --package jentic-openapi-transformer pytest packages/jentic-openapi-transformer/tests/test_bundle_redocly.py -v
+```

--- a/packages/jentic-openapi-bundler-redocly/pyproject.toml
+++ b/packages/jentic-openapi-bundler-redocly/pyproject.toml
@@ -1,0 +1,28 @@
+[project]
+name = "jentic-openapi-bundler-redocly"
+version = "0.1.0"
+description = "Jentic OpenAPI Redocly Bundler Strategy"
+readme = "README.md"
+authors = [{ name = "Jentic", email = "hello@jentic.com" }]
+license = { text = "Apache-2.0" }
+requires-python = ">=3.11"
+dependencies = [
+  "jentic-openapi-common",
+  "jentic-openapi-transformer",
+  "importlib-resources>=1.3.0;python_version<'3.9'"
+]
+
+[project.urls]
+Homepage = "https://github.com/jentic/jentic-openapi-tools"
+
+[tool.uv.sources]
+jentic-openapi-transformer = { workspace = true }
+
+[build-system]
+requires = ["uv_build>=0.8.15,<0.9.0"]
+build-backend = "uv_build"
+
+[project.entry-points."jentic.openapi_bundler_strategies"]
+redocly = "jentic_openapi_bundler_redocly.redocly_bundler:RedoclyBundler"
+
+

--- a/packages/jentic-openapi-bundler-redocly/src/jentic_openapi_bundler_redocly/__init__.py
+++ b/packages/jentic-openapi-bundler-redocly/src/jentic_openapi_bundler_redocly/__init__.py
@@ -1,0 +1,3 @@
+from .redocly_bundler import RedoclyBundler
+
+__all__ = ["RedoclyBundler"]

--- a/packages/jentic-openapi-bundler-redocly/src/jentic_openapi_bundler_redocly/redocly_bundler.py
+++ b/packages/jentic-openapi-bundler-redocly/src/jentic_openapi_bundler_redocly/redocly_bundler.py
@@ -1,0 +1,66 @@
+from typing import Any
+from urllib.parse import urlparse
+from urllib.request import url2pathname
+
+from jentic_openapi_transformer.strategies.base import BaseBundlerStrategy
+
+from jentic_openapi_common import run_checked, SubprocessExecutionError
+
+
+class RedoclyBundler(BaseBundlerStrategy):
+    def __init__(self, redocly_path: str = "redocly"):
+        """
+        Initialize the RedoclyBundler.
+
+        Args:
+            redocly_path: Path to the redocly CLI executable (default: "redocly")
+        """
+        self.redocly_path = redocly_path
+
+    def accepts(self) -> list[str]:
+        return ["uri"]
+
+    def bundle(self, document: str | dict, base_url: str | None = None) -> Any:
+        try:
+            assert isinstance(document, str)
+            return self._bundle(document, base_url)
+        except Exception as e:
+            # TODO add to parser/validation chain result
+            raise e
+
+    def _bundle(self, document: str, base_url: str | None = None) -> str:
+        try:
+            parsed_doc_url = urlparse(document)
+            doc_path = url2pathname(parsed_doc_url.path)
+            # Build redocly command
+            cmd = [
+                self.redocly_path,
+                "bundle",
+                doc_path,
+                "--ext",
+                "json",
+                "--lint-config",
+                "off",
+                "--force",
+                # "--remove-unused-components", # TODO, raises errors in redocly for some reason
+            ]
+            result = run_checked(cmd)
+        except SubprocessExecutionError as e:
+            # only timeout and OS errors, as run_checked has default `fail_on_error = False`
+            raise e
+
+        if result.stdout:
+            # When using `--force` Redocly tries bundling even on errors
+            output_lines = result.stdout.splitlines()
+            if output_lines and output_lines[-1].startswith("Created a bundle"):
+                output_lines = output_lines[:-1]
+
+            if result.returncode != 0 and result.stderr:
+                # TODO we need to add any errors to the parser/validation chain result
+                print(f"Error parsing document: {result.stderr}")
+
+            return "\n".join(output_lines)
+        else:
+            err = (result.stderr or "").strip()
+            msg = err or f"Redocly exited with code {result.returncode}"
+            raise Exception(msg)

--- a/packages/jentic-openapi-bundler-redocly/tests/fixtures/openapi/openapi.yaml
+++ b/packages/jentic-openapi-bundler-redocly/tests/fixtures/openapi/openapi.yaml
@@ -1,0 +1,146 @@
+openapi: 3.0.3
+info:
+  title: Users API
+  version: 1.0.0
+servers:
+  - url: https://api.example.com
+
+paths:
+  /users:
+    get:
+      summary: List users
+      description: Returns a paginated list of users.
+      parameters:
+        # External parameter
+        - $ref: ./parts/common.yaml#/components/parameters/TraceId
+        # Inline parameter (will be bundled inline)
+        - name: limit
+          in: query
+          description: Max results to return
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 200
+            default: 50
+      responses:
+        '200':
+          description: A page of users
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [items, pageInfo]
+                properties:
+                  items:
+                    type: array
+                    items:
+                      # External schema ref
+                      $ref: ./parts/common.yaml#/components/schemas/User
+                  pageInfo:
+                    # Inline schema with allOf composition and external ref
+                    allOf:
+                      - $ref: ./parts/common.yaml#/components/schemas/Paging
+                      - type: object
+                        properties:
+                          totalCount:
+                            type: integer
+                additionalProperties: false
+        '400':
+          $ref: ./parts/common.yaml#/components/responses/BadRequest
+    post:
+      summary: Create a new user
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              # Compose inline + external to see how bundling behaves
+              allOf:
+                - $ref: ./parts/common.yaml#/components/schemas/UserBase
+                - $ref: '#/components/schemas/NewUser'  # inline in this file
+      responses:
+        '201':
+          description: Created
+          headers:
+            Location:
+              description: URI of the newly created user
+              schema:
+                type: string
+                format: uri
+          content:
+            application/json:
+              schema:
+                $ref: ./parts/common.yaml#/components/schemas/User
+        '400':
+          $ref: ./parts/common.yaml#/components/responses/BadRequest
+
+  /users/{id}:
+    parameters:
+      # Path-level external parameter
+      - $ref: ./parts/common.yaml#/components/parameters/Id
+    get:
+      summary: Get user by ID
+      parameters:
+        - $ref: ./parts/common.yaml#/components/parameters/TraceId
+      responses:
+        '200':
+          description: User
+          content:
+            application/json:
+              schema:
+                $ref: ./parts/common.yaml#/components/schemas/User
+        '404':
+          $ref: ./parts/common.yaml#/components/responses/NotFound
+    patch:
+      summary: Update user (partial)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              # Inline, demonstrates oneOf with external/inline branches
+              type: object
+              properties:
+                name:
+                  type: string
+                  minLength: 1
+                address:
+                  oneOf:
+                    - $ref: ./parts/common.yaml#/components/schemas/Address
+                    - type: 'null'
+              additionalProperties: false
+      responses:
+        '200':
+          description: Updated user
+          content:
+            application/json:
+              schema:
+                $ref: ./parts/common.yaml#/components/schemas/User
+        '400':
+          $ref: ./parts/common.yaml#/components/responses/BadRequest
+        '404':
+          $ref: ./parts/common.yaml#/components/responses/NotFound
+
+components:
+  schemas:
+    # Inline schema used by POST /users payload (composed with UserBase)
+    NewUser:
+      type: object
+      required: [name, email]
+      properties:
+        name:
+          type: string
+          minLength: 1
+        email:
+          type: string
+          format: email
+        # Demonstrates inline map with $ref values
+        metadata:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: string
+              - type: number
+              - $ref: ./parts/common.yaml#/components/schemas/Address
+      additionalProperties: false

--- a/packages/jentic-openapi-bundler-redocly/tests/fixtures/openapi/parts/common.yaml
+++ b/packages/jentic-openapi-bundler-redocly/tests/fixtures/openapi/parts/common.yaml
@@ -1,0 +1,120 @@
+openapi: 3.0.3
+info:
+  title: Common Library
+  version: 1.0.0
+
+components:
+  parameters:
+    TraceId:
+      name: X-Trace-Id
+      in: header
+      description: Correlates logs and traces for a request
+      required: false
+      schema:
+        type: string
+        maxLength: 64
+    Id:
+      name: id
+      in: path
+      required: true
+      description: Resource identifier
+      schema:
+        $ref: '#/components/schemas/Id'
+
+  responses:
+    NotFound:
+      description: Resource not found
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    BadRequest:
+      description: Bad request
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+
+  schemas:
+    Id:
+      type: string
+      pattern: '^[a-zA-Z0-9_-]{6,32}$'
+
+    # Split base vs full to show composition in the root file
+    UserBase:
+      type: object
+      required: [name, email]
+      properties:
+        name:
+          type: string
+          minLength: 1
+        email:
+          type: string
+          format: email
+      additionalProperties: false
+
+    Address:
+      type: object
+      required: [street, city, country]
+      properties:
+        street:
+          type: string
+        city:
+          type: string
+        postalCode:
+          type: string
+        country:
+          type: string
+      additionalProperties: false
+
+    # Full User builds on UserBase; includes nested external refs
+    User:
+      allOf:
+        - $ref: '#/components/schemas/UserBase'
+        - type: object
+          required: [id]
+          properties:
+            id:
+              $ref: '#/components/schemas/Id'
+            address:
+              $ref: '#/components/schemas/Address'
+            roles:
+              type: array
+              items:
+                type: string
+                enum: [admin, editor, viewer]
+          additionalProperties: false
+
+    Paging:
+      type: object
+      required: [limit, offset, hasNext]
+      properties:
+        limit:
+          type: integer
+          minimum: 1
+        offset:
+          type: integer
+          minimum: 0
+        hasNext:
+          type: boolean
+      additionalProperties: false
+
+    Error:
+      type: object
+      required: [code, message]
+      properties:
+        code:
+          type: string
+          example: BAD_REQUEST
+        message:
+          type: string
+        details:
+          type: array
+          items:
+            type: object
+            properties:
+              path:
+                type: string
+              message:
+                type: string
+      additionalProperties: false

--- a/packages/jentic-openapi-bundler-redocly/tests/fixtures/openapi/simple_openapi.json
+++ b/packages/jentic-openapi-bundler-redocly/tests/fixtures/openapi/simple_openapi.json
@@ -1,0 +1,38 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "title": "Test API",
+        "description": "Test API",
+        "version": "1.0.0",
+        "contact": {
+            "name": "Jentic"
+        }
+    },
+    "servers": [
+        {
+            "url": "http://localhost:8080"
+        }
+    ],
+    "tags": [
+        {
+            "name": "test",
+            "description": "Test API"
+        }
+    ],
+    "paths": {
+        "/test": {
+            "get": {
+                "tags": [
+                    "test"
+                ],
+                "operationId": "getTest",
+                "description": "Test API",
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/packages/jentic-openapi-bundler-redocly/tests/fixtures/openapi/simple_openapi_invalid.json
+++ b/packages/jentic-openapi-bundler-redocly/tests/fixtures/openapi/simple_openapi_invalid.json
@@ -1,0 +1,38 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "title": "Test API",
+        "description": "Test API",
+        "version": 1,
+        "contact": {
+            "name": "Jentic"
+        }
+    },
+    "servers": [
+        {
+            "url": "http://localhost:8080"
+        }
+    ],
+    "tags": [
+        {
+            "name": "test",
+            "description": "Test API"
+        }
+    ],
+    "paths": {
+        "/test": {
+            "get": {
+                "tags": [
+                    "test"
+                ],
+                "operationId": "getTest",
+                "description": "Test API",
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/packages/jentic-openapi-bundler-redocly/tests/fixtures/openapi/simple_openapi_not_well_formed.json
+++ b/packages/jentic-openapi-bundler-redocly/tests/fixtures/openapi/simple_openapi_not_well_formed.json
@@ -1,0 +1,38 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "title: "Test API",
+        "description": "Test API",
+        "version": 1,
+        "contact": {
+            "name": "Jentic"
+        }
+    },
+    "servers": [
+        {
+            "url": "http://localhost:8080"
+        }
+    ],
+    "tags": [
+        {
+            "name": "test",
+            "description": "Test API"
+        }
+    ],
+    "paths": {
+        "/test": {
+            "get": {
+                "tags": [
+                    "test"
+                ],
+                "operationId": "getTest",
+                "description": "Test API",
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/packages/jentic-openapi-bundler-redocly/tests/fixtures/snapshots/openapi-bundled.json
+++ b/packages/jentic-openapi-bundler-redocly/tests/fixtures/snapshots/openapi-bundled.json
@@ -1,0 +1,414 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Users API",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://api.example.com"
+    }
+  ],
+  "paths": {
+    "/users": {
+      "get": {
+        "summary": "List users",
+        "description": "Returns a paginated list of users.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/TraceId"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Max results to return",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 200,
+              "default": 50
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A page of users",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "items",
+                    "pageInfo"
+                  ],
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/User"
+                      }
+                    },
+                    "pageInfo": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/Paging"
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "totalCount": {
+                              "type": "integer"
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a new user",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/UserBase"
+                  },
+                  {
+                    "$ref": "#/components/schemas/NewUser"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "headers": {
+              "Location": {
+                "description": "URI of the newly created user",
+                "schema": {
+                  "type": "string",
+                  "format": "uri"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          }
+        }
+      }
+    },
+    "/users/{id}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/Id"
+        }
+      ],
+      "get": {
+        "summary": "Get user by ID",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/TraceId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "User",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update user (partial)",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "address": {
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/Address"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated user",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "NewUser": {
+        "type": "object",
+        "required": [
+          "name",
+          "email"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "email": {
+            "type": "string",
+            "format": "email"
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "number"
+                },
+                {
+                  "$ref": "#/components/schemas/Address"
+                }
+              ]
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "UserBase": {
+        "type": "object",
+        "required": [
+          "name",
+          "email"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "email": {
+            "type": "string",
+            "format": "email"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Id": {
+        "type": "string",
+        "pattern": "^[a-zA-Z0-9_-]{6,32}$"
+      },
+      "Address": {
+        "type": "object",
+        "required": [
+          "street",
+          "city",
+          "country"
+        ],
+        "properties": {
+          "street": {
+            "type": "string"
+          },
+          "city": {
+            "type": "string"
+          },
+          "postalCode": {
+            "type": "string"
+          },
+          "country": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "User": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/UserBase"
+          },
+          {
+            "type": "object",
+            "required": [
+              "id"
+            ],
+            "properties": {
+              "id": {
+                "$ref": "#/components/schemas/Id"
+              },
+              "address": {
+                "$ref": "#/components/schemas/Address"
+              },
+              "roles": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "admin",
+                    "editor",
+                    "viewer"
+                  ]
+                }
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "Paging": {
+        "type": "object",
+        "required": [
+          "limit",
+          "offset",
+          "hasNext"
+        ],
+        "properties": {
+          "limit": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "offset": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "hasNext": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Error": {
+        "type": "object",
+        "required": [
+          "code",
+          "message"
+        ],
+        "properties": {
+          "code": {
+            "type": "string",
+            "example": "BAD_REQUEST"
+          },
+          "message": {
+            "type": "string"
+          },
+          "details": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "path": {
+                  "type": "string"
+                },
+                "message": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "parameters": {
+      "TraceId": {
+        "name": "X-Trace-Id",
+        "in": "header",
+        "description": "Correlates logs and traces for a request",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "maxLength": 64
+        }
+      },
+      "Id": {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "Resource identifier",
+        "schema": {
+          "$ref": "#/components/schemas/Id"
+        }
+      }
+    },
+    "responses": {
+      "BadRequest": {
+        "description": "Bad request",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      },
+      "NotFound": {
+        "description": "Resource not found",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/jentic-openapi-bundler-redocly/tests/fixtures/snapshots/openapi-bundled.yaml
+++ b/packages/jentic-openapi-bundler-redocly/tests/fixtures/snapshots/openapi-bundled.yaml
@@ -1,0 +1,255 @@
+info:
+  title: Users API
+  version: 1.0.0
+servers:
+  - url: https://api.example.com
+paths:
+  /users:
+    get:
+      summary: List users
+      description: Returns a paginated list of users.
+      parameters:
+        - $ref: '#/components/parameters/TraceId'
+        - name: limit
+          in: query
+          description: Max results to return
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 200
+            default: 50
+      responses:
+        '200':
+          description: A page of users
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - items
+                  - pageInfo
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/User'
+                  pageInfo:
+                    allOf:
+                      - $ref: '#/components/schemas/Paging'
+                      - type: object
+                        properties:
+                          totalCount:
+                            type: integer
+                additionalProperties: false
+        '400':
+          $ref: '#/components/responses/BadRequest'
+    post:
+      summary: Create a new user
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/UserBase'
+                - $ref: '#/components/schemas/NewUser'
+      responses:
+        '201':
+          description: Created
+          headers:
+            Location:
+              description: URI of the newly created user
+              schema:
+                type: string
+                format: uri
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+  /users/{id}:
+    parameters:
+      - $ref: '#/components/parameters/Id'
+    get:
+      summary: Get user by ID
+      parameters:
+        - $ref: '#/components/parameters/TraceId'
+      responses:
+        '200':
+          description: User
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    patch:
+      summary: Update user (partial)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  minLength: 1
+                address:
+                  oneOf:
+                    - $ref: '#/components/schemas/Address'
+                    - type: 'null'
+              additionalProperties: false
+      responses:
+        '200':
+          description: Updated user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+components:
+  schemas:
+    NewUser:
+      type: object
+      required:
+        - name
+        - email
+      properties:
+        name:
+          type: string
+          minLength: 1
+        email:
+          type: string
+          format: email
+        metadata:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: string
+              - type: number
+              - $ref: '#/components/schemas/Address'
+      additionalProperties: false
+    UserBase:
+      type: object
+      required:
+        - name
+        - email
+      properties:
+        name:
+          type: string
+          minLength: 1
+        email:
+          type: string
+          format: email
+      additionalProperties: false
+    Id:
+      type: string
+      pattern: ^[a-zA-Z0-9_-]{6,32}$
+    Address:
+      type: object
+      required:
+        - street
+        - city
+        - country
+      properties:
+        street:
+          type: string
+        city:
+          type: string
+        postalCode:
+          type: string
+        country:
+          type: string
+      additionalProperties: false
+    User:
+      allOf:
+        - $ref: '#/components/schemas/UserBase'
+        - type: object
+          required:
+            - id
+          properties:
+            id:
+              $ref: '#/components/schemas/Id'
+            address:
+              $ref: '#/components/schemas/Address'
+            roles:
+              type: array
+              items:
+                type: string
+                enum:
+                  - admin
+                  - editor
+                  - viewer
+          additionalProperties: false
+    Paging:
+      type: object
+      required:
+        - limit
+        - offset
+        - hasNext
+      properties:
+        limit:
+          type: integer
+          minimum: 1
+        offset:
+          type: integer
+          minimum: 0
+        hasNext:
+          type: boolean
+      additionalProperties: false
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: string
+          example: BAD_REQUEST
+        message:
+          type: string
+        details:
+          type: array
+          items:
+            type: object
+            properties:
+              path:
+                type: string
+              message:
+                type: string
+      additionalProperties: false
+  parameters:
+    TraceId:
+      name: X-Trace-Id
+      in: header
+      description: Correlates logs and traces for a request
+      required: false
+      schema:
+        type: string
+        maxLength: 64
+    Id:
+      name: id
+      in: path
+      required: true
+      description: Resource identifier
+      schema:
+        $ref: '#/components/schemas/Id'
+  responses:
+    BadRequest:
+      description: Bad request
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    NotFound:
+      description: Resource not found
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'

--- a/packages/jentic-openapi-bundler-redocly/tests/test_bundle.py
+++ b/packages/jentic-openapi-bundler-redocly/tests/test_bundle.py
@@ -1,0 +1,59 @@
+import subprocess
+import pytest
+from pathlib import Path
+
+from jentic_openapi_bundler_redocly import RedoclyBundler
+from jentic_openapi_common import SubprocessExecutionError
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures" / "openapi"
+SNAPSHOTS_DIR = Path(__file__).parent / "fixtures" / "snapshots"
+
+
+@pytest.mark.skipif(
+    subprocess.run(["redocly", "--version"], capture_output=True).returncode != 0,
+    reason="Redocly CLI not available",
+)
+def test_redocly_bundler_ok():
+    spec_file = FIXTURES_DIR / "openapi.yaml"
+    spec_uri = spec_file.as_uri()
+
+    expected = (SNAPSHOTS_DIR / "openapi-bundled.json").read_text(encoding="utf-8")
+
+    bundler = RedoclyBundler()
+    assert bundler is not None
+    assert bundler.redocly_path == "redocly"
+    result = bundler.bundle(spec_uri)
+    assert result == expected
+    # assert "Redocly CLI not found" in str(result.diagnostics[0].message)
+
+
+@pytest.mark.skipif(
+    subprocess.run(["redocly", "--version"], capture_output=True).returncode != 0,
+    reason="Redocly CLI not available",
+)
+def test_redocly_bundler_failure():
+    spec_file = FIXTURES_DIR / "simple_openapi_not_well_formed.json"
+    spec_uri = spec_file.as_uri()
+
+    bundler = RedoclyBundler()
+    assert bundler is not None
+    assert bundler.redocly_path == "redocly"
+    with pytest.raises(Exception, match="Failed to parse API"):
+        bundler.bundle(spec_uri)
+
+
+def test_redocly_bundler_custom_path():
+    """Test RedoclyBundler with custom redocly path."""
+    bundler = RedoclyBundler(redocly_path="/custom/path/to/redocly")
+    assert bundler.redocly_path == "/custom/path/to/redocly"
+
+
+def test_redocly_bundler_without_cli():
+    """Test RedoclyBundler behavior when redocly CLI is not available."""
+    bundler = RedoclyBundler(redocly_path="nonexistent_redocly")
+    # This would need a file path, not a dict - the current implementation
+    # expects a file path to pass to redocly CLI
+    try:
+        bundler.bundle("/some/test/file.yaml")
+    except SubprocessExecutionError as e:
+        assert "[Errno 2] No such file or directory: 'nonexistent_redocly'" in str(e.stderr)

--- a/packages/jentic-openapi-transformer/pyproject.toml
+++ b/packages/jentic-openapi-transformer/pyproject.toml
@@ -11,8 +11,13 @@ dependencies = ["jentic-openapi-parser"]
 [project.urls]
 Homepage = "https://github.com/jentic/jentic-openapi-tools"
 
+[project.optional-dependencies]
+redocly = ["jentic-openapi-bundler-redocly"]
+
 [tool.uv.sources]
 jentic-openapi-parser = { workspace = true }
+jentic-openapi-bundler-redocly = { workspace = true }
+
 
 [build-system]
 requires = ["uv_build>=0.8.15,<0.9.0"]

--- a/packages/jentic-openapi-transformer/src/jentic_openapi_transformer/__init__.py
+++ b/packages/jentic-openapi-transformer/src/jentic_openapi_transformer/__init__.py
@@ -1,3 +1,4 @@
 from .transform import normalize
+from .openapi_bundler import OpenAPIBundler
 
-__all__ = ["normalize"]
+__all__ = ["OpenAPIBundler", "normalize"]

--- a/packages/jentic-openapi-transformer/src/jentic_openapi_transformer/openapi_bundler.py
+++ b/packages/jentic-openapi-transformer/src/jentic_openapi_transformer/openapi_bundler.py
@@ -1,0 +1,188 @@
+import importlib.metadata
+from typing import Any, TypeVar, cast, overload, Mapping, Sequence
+import json
+
+from jentic_openapi_parser import OpenAPIParser
+from .strategies.base import BaseBundlerStrategy
+from .strategies.default_strategy import DefaultOpenAPIBundler
+
+T = TypeVar("T")
+
+
+class OpenAPIBundler:
+    """
+    Provides a bundler for OpenAPI specifications using customizable strategies.
+
+    This class is designed to facilitate the bundling of OpenAPI documents.
+    It supports multiple strategies and can be extended through plugins.
+    When multiple strategies are used, the returned value is the result from the last strategy of the list that succeeds.
+    This mechanism is designed to allow passing multiple strategies to the bundler and concur to the validation process
+    by reporting the errors and success status from all strategies.
+
+    Attributes:
+        strategies (list[BaseParserStrategy]): List of strategies used by the bundler,
+        each implementing the BaseBundlerStrategy interface.
+    """
+
+    def __init__(self, strategies: list | None = None, parser: OpenAPIParser | None = None):
+        if not parser:
+            parser = OpenAPIParser()
+        self.parser = parser
+        # If no strategies specified, use default
+        if not strategies:
+            strategies = ["default"]
+        self.strategies = []  # list of BaseBundlerStrategy instances
+
+        # Discover entry points for bundler plugins
+        # (This could be a one-time load stored at class level to avoid doing it every time)
+        eps = importlib.metadata.entry_points(group="jentic.openapi_bundler_strategies")
+        plugin_map = {ep.name: ep for ep in eps}
+
+        for strat in strategies:
+            if isinstance(strat, str):
+                name = strat
+                if name == "default":
+                    # Use built-in default bundler (TODO NOOP atm)
+                    self.strategies.append(DefaultOpenAPIBundler())
+                elif name in plugin_map:
+                    plugin_class = plugin_map[name].load()  # loads the class
+                    self.strategies.append(plugin_class())
+                else:
+                    raise ValueError(f"No bundler plugin named '{name}' found")
+            elif isinstance(strat, BaseBundlerStrategy):
+                self.strategies.append(strat)
+            elif hasattr(strat, "__call__") and issubclass(strat, BaseBundlerStrategy):
+                # if a class (not instance) is passed
+                self.strategies.append(strat())
+            else:
+                raise TypeError("Invalid strategy type: must be name or strategy class/instance")
+
+    @overload
+    def bundle(
+        self,
+        source: str | dict,
+        base_url: str | None = None,
+        *,
+        return_type: type[str],
+        strict: bool = False,
+    ) -> str: ...
+
+    @overload
+    def bundle(
+        self,
+        source: str | dict,
+        base_url: str | None = None,
+        *,
+        return_type: type[dict[str, Any]],
+        strict: bool = False,
+    ) -> dict[str, Any]: ...
+
+    @overload
+    def bundle(
+        self,
+        source: str | dict,
+        base_url: str | None = None,
+        *,
+        return_type: type[T],
+        strict: bool = False,
+    ) -> T: ...
+
+    def bundle(
+        self,
+        source: str | dict,
+        base_url: str | None = None,
+        *,
+        return_type: type[T] | None = None,
+        strict: bool = False,
+    ) -> Any:
+        raw = self._bundle(source, base_url)
+
+        if return_type is None:
+            return self._to_plain(raw)
+
+        # Handle conversion to string type
+        if return_type is str and not isinstance(raw, str):
+            if isinstance(raw, (dict, list)):
+                return cast(T, json.dumps(raw))
+            else:
+                return cast(T, str(raw))
+
+        # Handle conversion from string to dict type
+        if return_type is dict and isinstance(raw, str):
+            try:
+                return cast(T, json.loads(raw))
+            except json.JSONDecodeError:
+                if strict:
+                    raise ValueError(f"Cannot parse string as JSON: {raw}")
+                return cast(T, raw)
+
+        if strict:
+            if not isinstance(raw, return_type):
+                raise TypeError(
+                    f"Expected {getattr(return_type, '__name__', return_type)}, "
+                    f"got {type(raw).__name__}"
+                )
+        return cast(T, raw)
+
+    def _bundle(self, source: str | dict, base_url: str | None = None) -> Any:
+        text = source
+        data = None
+        result = None
+        if isinstance(source, str):
+            is_uri = self.parser.is_uri_like(source)
+            is_text = not is_uri
+
+            if is_text:
+                data = self.parser.parse(source)
+
+            if is_uri and self.has_non_uri_strategy():
+                text = self.parser.load_uri(source)
+                if not data or data is None:
+                    data = self.parser.parse(text)
+        else:
+            is_uri = False
+        if not data or data is None:
+            data = text
+
+        for strat in self.strategies:
+            document = None
+            if is_uri and "uri" in strat.accepts():
+                document = source
+            elif is_uri and "text" in strat.accepts():
+                document = text
+            elif is_uri and "dict" in strat.accepts():
+                document = data
+            elif not is_uri and "text" in strat.accepts():
+                document = text
+            elif not is_uri and "dict" in strat.accepts():
+                document = data
+
+            if document is not None:
+                try:
+                    result = strat.bundle(document)
+                except Exception as e:
+                    # TODO add to parser/validation chain result
+                    print(f"Error parsing document: {e}")
+        if result is None:
+            raise ValueError("No valid document found")
+        return result
+
+    def has_non_uri_strategy(self) -> bool:
+        """Check if any strategy accepts 'text' or 'dict' but not 'uri'."""
+        for strat in self.strategies:
+            accepted = strat.accepts()
+            if ("text" in accepted or "dict" in accepted) and "uri" not in accepted:
+                return True
+        return False
+
+    def _to_plain(self, obj: Any) -> Any:
+        # Mapping?
+        if isinstance(obj, Mapping):
+            return {k: self._to_plain(v) for k, v in obj.items()}
+
+        # Sequence but NOT str/bytes
+        if isinstance(obj, Sequence) and not isinstance(obj, (str, bytes, bytearray)):
+            return [self._to_plain(x) for x in obj]
+
+        # Scalar
+        return obj

--- a/packages/jentic-openapi-transformer/src/jentic_openapi_transformer/strategies/base.py
+++ b/packages/jentic-openapi-transformer/src/jentic_openapi_transformer/strategies/base.py
@@ -1,0 +1,16 @@
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class BaseBundlerStrategy(ABC):
+    """Interface that all Bundler plugins must implement."""
+
+    @abstractmethod
+    def bundle(self, document: str | dict, base_url: str | None = None) -> Any:
+        """Bundle an OpenAPI document given by URI or file path or text.
+        Returns a BundlerResult."""
+        pass
+
+    @abstractmethod
+    def accepts(self) -> list[str]:
+        pass

--- a/packages/jentic-openapi-transformer/src/jentic_openapi_transformer/strategies/default_strategy.py
+++ b/packages/jentic-openapi-transformer/src/jentic_openapi_transformer/strategies/default_strategy.py
@@ -1,0 +1,19 @@
+from typing import Any
+from .base import BaseBundlerStrategy
+
+
+class DefaultOpenAPIBundler(BaseBundlerStrategy):
+    def bundle(self, document: str | dict, base_url: str | None = None) -> Any:
+        try:
+            assert isinstance(document, dict)
+            return self._bundle(document, base_url)  # TODO implement real bundler
+        except Exception as e:
+            # TODO add to parser/validation chain result
+            raise e
+
+    def _bundle(self, document: str | dict, base_url: str | None = None) -> str | dict:
+        # TODO real native implementation, replace placeholder
+        return document
+
+    def accepts(self) -> list[str]:
+        return ["dict"]

--- a/packages/jentic-openapi-transformer/tests/fixtures/openapi/simple_openapi.json
+++ b/packages/jentic-openapi-transformer/tests/fixtures/openapi/simple_openapi.json
@@ -1,0 +1,19 @@
+{
+    "openapi": "3.1.0",
+    "info": {
+        "title": "Test API",
+        "version": "1.0.0"
+    },
+    "paths": {
+        "/test": {
+            "get": {
+                "operationId": "getTest",
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/packages/jentic-openapi-transformer/tests/test_bundle.py
+++ b/packages/jentic-openapi-transformer/tests/test_bundle.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+from jentic_openapi_transformer import OpenAPIBundler
+
+# Get the fixtures directory
+FIXTURES_DIR = Path(__file__).parent / "fixtures" / "openapi"
+
+
+def test_bundle_json_url_return_str():
+    spec_file = FIXTURES_DIR / "simple_openapi.json"
+    spec_uri = spec_file.as_uri()
+
+    bundler = OpenAPIBundler()
+    doc = bundler.bundle(spec_uri, return_type=str)
+    assert isinstance(doc, str)
+
+
+def test_bundle_json_url_return_dict():
+    spec_file = FIXTURES_DIR / "simple_openapi.json"
+    spec_uri = spec_file.as_uri()
+
+    bundler = OpenAPIBundler()
+    doc = bundler.bundle(spec_uri, return_type=dict)
+    assert isinstance(doc, dict)
+    assert doc["openapi"] == "3.1.0"
+    assert doc["info"]["title"] == "Test API"
+
+
+def test_parse_json_string():
+    bundler = OpenAPIBundler()
+    doc = bundler.bundle(
+        '{"openapi":"3.1.0","info":{"title":"x","version":"1.0.0"}}', return_type=dict
+    )
+    assert doc["openapi"] == "3.1.0"
+    assert doc["info"]["title"] == "x"
+
+
+def test_parse_default_strategy():
+    """Test that the strategy mechanism works."""
+    bundler = OpenAPIBundler(["default"])
+    assert len(bundler.strategies) == 1
+
+    # Verify the strategy types
+    strategy_names = [type(s).__name__ for s in bundler.strategies]
+    assert "DefaultOpenAPIBundler" in strategy_names
+    doc = bundler.bundle(
+        '{"openapi":"3.1.0","info":{"title":"x","version":"1.0.0"}}', return_type=dict
+    )
+    assert doc["openapi"] == "3.1.0"
+    assert doc["info"]["title"] == "x"

--- a/packages/jentic-openapi-transformer/tests/test_bundle_redocly.py
+++ b/packages/jentic-openapi-transformer/tests/test_bundle_redocly.py
@@ -1,0 +1,102 @@
+import subprocess
+import pytest
+from jentic_openapi_transformer import OpenAPIBundler
+
+
+@pytest.fixture
+def sample_openapi_file(tmp_path):
+    """Create a temporary OpenAPI file for testing."""
+    openapi_content = """
+openapi: 3.1.0
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /users:
+    get:
+      summary: Get users
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+"""
+    openapi_file = tmp_path / "test_api.yaml"
+    openapi_file.write_text(openapi_content.strip())
+    return str(openapi_file)
+
+
+def test_redocly_plugin_discovery():
+    """Test that the redocly plugin can be discovered via entry points."""
+    try:
+        # This should work if jentic-openapi-bundler-redocly is installed
+        bundler = OpenAPIBundler(["default", "redocly"])
+        assert len(bundler.strategies) == 2
+
+        # Verify the strategy types
+        strategy_names = [type(s).__name__ for s in bundler.strategies]
+        assert "DefaultOpenAPIBundler" in strategy_names
+        assert "RedoclyBundler" in strategy_names
+
+    except ValueError as e:
+        if "No bundler plugin named 'redocly' found" in str(e):
+            pytest.skip("jentic-openapi-bundler-redocly not installed - skipping integration test")
+        else:
+            raise
+
+
+@pytest.mark.skipif(
+    subprocess.run(["redocly", "--version"], capture_output=True).returncode != 0,
+    reason="Redocly CLI not available",
+)
+def test_redocly_only_strategy(sample_openapi_file):
+    """Test using only the redocly strategy."""
+    try:
+        bundler = OpenAPIBundler(["redocly"])
+        result = bundler.bundle(sample_openapi_file, return_type=str)
+
+        # With real redocly CLI, we should get actual validation results
+        assert result is not None and isinstance(result, str) and len(result) > 0
+
+        assert len(bundler.strategies) == 1
+        assert type(bundler.strategies[0]).__name__ == "RedoclyBundler"
+
+    except ValueError as e:
+        if "No bundler plugin named 'redocly' found" in str(e):
+            pytest.skip("jentic-openapi-bundler-redocly not installed - skipping integration test")
+        else:
+            raise
+
+
+@pytest.mark.skipif(
+    subprocess.run(["redocly", "--version"], capture_output=True).returncode != 0,
+    reason="Redocly CLI not available",
+)
+def test_invalid_strategy_name():
+    """Test that invalid strategy names raise appropriate errors."""
+    with pytest.raises(ValueError, match="No bundler plugin named 'nonexistent' found"):
+        OpenAPIBundler(["nonexistent"])
+
+
+@pytest.mark.skipif(
+    subprocess.run(["redocly", "--version"], capture_output=True).returncode != 0,
+    reason="Redocly CLI not available",
+)
+def test_redocly_with_real_cli(sample_openapi_file):
+    """Test redocly integration when the actual redocly CLI is available."""
+    try:
+        bundler = OpenAPIBundler(["redocly"])
+        result = bundler.bundle(sample_openapi_file, return_type=str)
+
+        # With real redocly CLI, we should get actual validation results
+        assert result is not None and isinstance(result, str) and len(result) > 0
+
+    except ValueError as e:
+        if "No bundler plugin named 'redocly' found" in str(e):
+            pytest.skip("jentic-openapi-bundler-redocly not installed")
+        else:
+            raise

--- a/packages/jentic-openapi-validator-spectral/tests/test_validate.py
+++ b/packages/jentic-openapi-validator-spectral/tests/test_validate.py
@@ -1,8 +1,8 @@
 import subprocess
+import pytest
 from pathlib import Path
 
 from jentic_openapi_common.subprocess import SubprocessExecutionError
-import pytest
 from jentic_openapi_validator_spectral import SpectralValidator
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures" / "openapi"

--- a/packages/jentic-openapi-validator/src/jentic_openapi_validator/openapi_validator.py
+++ b/packages/jentic-openapi-validator/src/jentic_openapi_validator/openapi_validator.py
@@ -42,9 +42,8 @@ class OpenAPIValidator:
 
     def validate(self, source: str | dict) -> ValidationResult:
         text = source
-        data = text
         all_messages = []
-
+        data = None
         if isinstance(source, str):
             is_uri = self.parser.is_uri_like(source)
             is_text = not is_uri
@@ -54,11 +53,13 @@ class OpenAPIValidator:
 
             if is_uri and self.has_non_uri_strategy():
                 text = self.parser.load_uri(source)
-                if not data:
+                if not data or data is None:
                     data = self.parser.parse(text)
         else:
             is_uri = False
             is_text = False
+        if not data or data is None:
+            data = text
 
         for strat in self.strategies:
             document = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ src = [
   "packages/jentic-openapi-transformer/src",
   "packages/jentic-openapi-validator/src",
   "packages/jentic-openapi-validator-spectral/src",
+  "packages/jentic-openapi-bundler-redocly/src",
 ]
 
 [tool.pyright]
@@ -76,6 +77,7 @@ version_pattern = [
     "packages/jentic-openapi-transformer/pyproject.toml:version = \"{version}\"",
     "packages/jentic-openapi-validator/pyproject.toml:version = \"{version}\"",
     "packages/jentic-openapi-validator-spectral/pyproject.toml:version = \"{version}\"",
+    "packages/jentic-openapi-bundler-redocly/pyproject.toml:version = \"{version}\"",
 ]
 
 # Commit message template for version commits

--- a/src/jentic_openapi_tools/__init__.py
+++ b/src/jentic_openapi_tools/__init__.py
@@ -2,6 +2,7 @@
 
 from jentic_openapi_parser import OpenAPIParser
 from jentic_openapi_validator import OpenAPIValidator, ValidationResult
+from jentic_openapi_transformer import OpenAPIBundler
 from lsprotocol.types import Diagnostic
 
-__all__ = ["OpenAPIParser", "OpenAPIValidator", "ValidationResult", "Diagnostic"]
+__all__ = ["OpenAPIParser", "OpenAPIValidator", "ValidationResult", "Diagnostic", "OpenAPIBundler"]

--- a/templates/CHANGELOG.md.j2
+++ b/templates/CHANGELOG.md.j2
@@ -10,6 +10,7 @@
 - jentic-openapi-transformer {{ version }}
 - jentic-openapi-validator {{ version }}
 - jentic-openapi-validator-spectral {{ version }}
+- jentic-openapi-bundler-redocly {{ version }}
 
 {% if release.elements.breaking %}
 ### ⚠ BREAKING CHANGES

--- a/uv.lock
+++ b/uv.lock
@@ -4,6 +4,7 @@ requires-python = ">=3.11"
 
 [manifest]
 members = [
+    "jentic-openapi-bundler-redocly",
     "jentic-openapi-parser",
     "jentic-openapi-tools",
     "jentic-openapi-transformer",
@@ -246,6 +247,22 @@ wheels = [
 ]
 
 [[package]]
+name = "jentic-openapi-bundler-redocly"
+version = "0.1.0"
+source = { editable = "packages/jentic-openapi-bundler-redocly" }
+dependencies = [
+    { name = "jentic-openapi-common" },
+    { name = "jentic-openapi-transformer" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "importlib-resources", marker = "python_full_version < '3.9'", specifier = ">=1.3.0" },
+    { name = "jentic-openapi-common", editable = "jentic-openapi-common" },
+    { name = "jentic-openapi-transformer", editable = "packages/jentic-openapi-transformer" },
+]
+
+[[package]]
 name = "jentic-openapi-common"
 version = "0.1.0"
 source = { editable = "jentic-openapi-common" }
@@ -294,8 +311,17 @@ dependencies = [
     { name = "jentic-openapi-parser" },
 ]
 
+[package.optional-dependencies]
+redocly = [
+    { name = "jentic-openapi-bundler-redocly" },
+]
+
 [package.metadata]
-requires-dist = [{ name = "jentic-openapi-parser", editable = "packages/jentic-openapi-parser" }]
+requires-dist = [
+    { name = "jentic-openapi-bundler-redocly", marker = "extra == 'redocly'", editable = "packages/jentic-openapi-bundler-redocly" },
+    { name = "jentic-openapi-parser", editable = "packages/jentic-openapi-parser" },
+]
+provides-extras = ["redocly"]
 
 [[package]]
 name = "jentic-openapi-validator"


### PR DESCRIPTION
Introduce `jentic-openapi-bundler-redocly` package to enable Redocly-based OpenAPI bundling:

- Implement `RedoclyBundler` bundling strategy within the new package.
- Add CLI and entry-point configuration to support plugin discovery and extensibility.
- Update `jentic-openapi-transformer` with Redocly bundling integration.
- Introduce comprehensive test coverage for Redocly bundling edge cases and CLI compatibility.
- Update workflows (release/pre-release) and `pyproject.toml` to include new package.
- Add documentation and changelog entries for Redocly support.
- Adapt Spectral Validator and Validator packages to changes in subprocess result