### PR TITLE
refactor(parser, transformer): simplify strategy handling to use single strategy at a time

### DIFF
--- a/packages/jentic-openapi-parser/tests/test_parse.py
+++ b/packages/jentic-openapi-parser/tests/test_parse.py
@@ -1,7 +1,5 @@
 from pathlib import Path
 
-import pytest
-
 from jentic_openapi_parser import OpenAPIParser
 from ruamel.yaml import CommentedMap
 
@@ -28,12 +26,10 @@ def test_parse_json_string():
 
 def test_parse_default_strategy():
     """Test that the strategy mechanism works."""
-    parser = OpenAPIParser(["default"])
-    assert len(parser.strategies) == 1
-
+    parser = OpenAPIParser("default")
     # Verify the strategy types
-    strategy_names = [type(s).__name__ for s in parser.strategies]
-    assert "DefaultOpenAPIParser" in strategy_names
+    strategy_name = type(parser.strategy).__name__
+    assert strategy_name == "DefaultOpenAPIParser"
     doc = parser.parse('{"openapi":"3.1.0","info":{"title":"x","version":"1.0.0"}}')
     assert doc["openapi"] == "3.1.0"
     assert doc["info"]["title"] == "x"
@@ -41,10 +37,9 @@ def test_parse_default_strategy():
 
 def test_parse_ruamel_strategy():
     """Test ruamel parser."""
-    parser = OpenAPIParser(["ruamel"])
-    assert len(parser.strategies) == 1
-    strategy_names = [type(s).__name__ for s in parser.strategies]
-    assert "RuamelOpenAPIParser" in strategy_names
+    parser = OpenAPIParser("ruamel")
+    strategy_name = type(parser.strategy).__name__
+    assert strategy_name == "RuamelOpenAPIParser"
 
     doc = parser.parse('{"openapi":"3.1.0","info":{"title":"x","version":"1.0.0"}}')
     assert doc["openapi"] == "3.1.0"
@@ -54,10 +49,9 @@ def test_parse_ruamel_strategy():
 
 def test_parse_ruamel_roundtrip_strategy():
     """Test ruamel-rt parser."""
-    parser = OpenAPIParser(["ruamel-rt"])
-    assert len(parser.strategies) == 1
-    strategy_names = [type(s).__name__ for s in parser.strategies]
-    assert "RuamelRoundTripOpenAPIParser" in strategy_names
+    parser = OpenAPIParser("ruamel-rt")
+    strategy_name = type(parser.strategy).__name__
+    assert strategy_name == "RuamelRoundTripOpenAPIParser"
 
     doc = parser.parse(
         '{"openapi":"3.1.0","info":{"title":"x","version":"1.0.0"}}', return_type=CommentedMap
@@ -65,42 +59,3 @@ def test_parse_ruamel_roundtrip_strategy():
     assert doc["openapi"] == "3.1.0"
     assert doc["info"]["title"] == "x"
     assert hasattr(doc, "lc")  # ruamel roundtrip keeps line/col info
-
-
-def test_parse_default_and_ruamel_roundtrip_strategy():
-    """Test default and ruamel-rt parser."""
-    parser = OpenAPIParser(["default", "ruamel-rt"])
-    assert len(parser.strategies) == 2
-    strategy_names = [type(s).__name__ for s in parser.strategies]
-    assert "DefaultOpenAPIParser" in strategy_names
-    assert "RuamelRoundTripOpenAPIParser" in strategy_names
-
-    doc = parser.parse(
-        '{"openapi":"3.1.0","info":{"title":"x","version":"1.0.0"}}', return_type=CommentedMap
-    )
-    assert doc["openapi"] == "3.1.0"
-    assert doc["info"]["title"] == "x"
-    assert hasattr(doc, "lc")  # ruamel roundtrip keeps line/col info
-
-
-def test_parse_and_ruamel_roundtrip_and_default_strategy():
-    """Test ruamel-rt and default parser."""
-    parser = OpenAPIParser(["ruamel-rt", "default"])
-    assert len(parser.strategies) == 2
-    strategy_names = [type(s).__name__ for s in parser.strategies]
-    assert "DefaultOpenAPIParser" in strategy_names
-    assert "RuamelRoundTripOpenAPIParser" in strategy_names
-
-    doc = parser.parse(
-        '{"openapi":"3.1.0","info":{"title":"x","version":"1.0.0"}}', return_type=CommentedMap
-    )
-    assert doc["openapi"] == "3.1.0"
-    assert doc["info"]["title"] == "x"
-    assert not hasattr(doc, "lc")  # default strategy is last and returns a dict
-
-    with pytest.raises(TypeError):
-        doc = parser.parse(
-            '{"openapi":"3.1.0","info":{"title":"x","version":"1.0.0"}}',
-            return_type=CommentedMap,
-            strict=True,
-        )

--- a/packages/jentic-openapi-transformer/tests/test_bundle.py
+++ b/packages/jentic-openapi-transformer/tests/test_bundle.py
@@ -36,12 +36,10 @@ def test_parse_json_string():
 
 def test_parse_default_strategy():
     """Test that the strategy mechanism works."""
-    bundler = OpenAPIBundler(["default"])
-    assert len(bundler.strategies) == 1
-
+    bundler = OpenAPIBundler("default")
     # Verify the strategy types
-    strategy_names = [type(s).__name__ for s in bundler.strategies]
-    assert "DefaultOpenAPIBundler" in strategy_names
+    strategy_name = type(bundler.strategy).__name__
+    assert strategy_name == "DefaultOpenAPIBundler"
     doc = bundler.bundle(
         '{"openapi":"3.1.0","info":{"title":"x","version":"1.0.0"}}', return_type=dict
     )

--- a/packages/jentic-openapi-transformer/tests/test_bundle_redocly.py
+++ b/packages/jentic-openapi-transformer/tests/test_bundle_redocly.py
@@ -34,13 +34,10 @@ def test_redocly_plugin_discovery():
     """Test that the redocly plugin can be discovered via entry points."""
     try:
         # This should work if jentic-openapi-bundler-redocly is installed
-        bundler = OpenAPIBundler(["default", "redocly"])
-        assert len(bundler.strategies) == 2
-
+        bundler = OpenAPIBundler("redocly")
         # Verify the strategy types
-        strategy_names = [type(s).__name__ for s in bundler.strategies]
-        assert "DefaultOpenAPIBundler" in strategy_names
-        assert "RedoclyBundler" in strategy_names
+        strategy_name = type(bundler.strategy).__name__
+        assert strategy_name == "RedoclyBundler"
 
     except ValueError as e:
         if "No bundler plugin named 'redocly' found" in str(e):
@@ -56,14 +53,13 @@ def test_redocly_plugin_discovery():
 def test_redocly_only_strategy(sample_openapi_file):
     """Test using only the redocly strategy."""
     try:
-        bundler = OpenAPIBundler(["redocly"])
+        bundler = OpenAPIBundler("redocly")
         result = bundler.bundle(sample_openapi_file, return_type=str)
 
         # With real redocly CLI, we should get actual validation results
         assert result is not None and isinstance(result, str) and len(result) > 0
 
-        assert len(bundler.strategies) == 1
-        assert type(bundler.strategies[0]).__name__ == "RedoclyBundler"
+        assert type(bundler.strategy).__name__ == "RedoclyBundler"
 
     except ValueError as e:
         if "No bundler plugin named 'redocly' found" in str(e):
@@ -79,7 +75,7 @@ def test_redocly_only_strategy(sample_openapi_file):
 def test_invalid_strategy_name():
     """Test that invalid strategy names raise appropriate errors."""
     with pytest.raises(ValueError, match="No bundler plugin named 'nonexistent' found"):
-        OpenAPIBundler(["nonexistent"])
+        OpenAPIBundler("nonexistent")
 
 
 @pytest.mark.skipif(
@@ -89,7 +85,7 @@ def test_invalid_strategy_name():
 def test_redocly_with_real_cli(sample_openapi_file):
     """Test redocly integration when the actual redocly CLI is available."""
     try:
-        bundler = OpenAPIBundler(["redocly"])
+        bundler = OpenAPIBundler("redocly")
         result = bundler.bundle(sample_openapi_file, return_type=str)
 
         # With real redocly CLI, we should get actual validation results


### PR DESCRIPTION


Replace multi-strategy handling with a single-strategy approach for `OpenAPIParser` and `OpenAPIBundler`:

- Update constructors to accept a single `strategy` instead of a list of strategies.
- Simplify logic in `openapi_parser.py` and `openapi_bundler.py` to work with a single strategy instance.
- Refactor associated tests to align with the updated single-strategy behavior.
- Remove support for multiple strategies within the same instance.