### PR TITLE
fix(parser): fix conflict in ruamel parser naming

### DIFF
--- a/packages/jentic-openapi-parser/README.md
+++ b/packages/jentic-openapi-parser/README.md
@@ -68,8 +68,8 @@ doc = parser.parse(yaml_doc, return_type=CommentedMap, strict=True)
 parser = OpenAPIParser("pyyaml")
 doc = parser.parse("file:///path/to/openapi.yaml")
 
-# Use ruamel.yaml backend
-parser = OpenAPIParser("ruamel")
+# Use ruamel.yaml backend (safe mode)
+parser = OpenAPIParser("ruamel-safe")
 doc = parser.parse("file:///path/to/openapi.yaml")
 
 # Use ruamel.yaml roundtrip mode (preserves comments and formatting info)
@@ -153,7 +153,7 @@ class OpenAPIParser:
 
 **Parameters:**
 - `backend`: Parser backend to use. Can be:
-  - `str`: Name of a backend registered via entry points (e.g., "pyyaml", "ruamel", "ruamel-roundtrip")
+  - `str`: Name of a backend registered via entry points (e.g., "pyyaml", "ruamel-safe", "ruamel-roundtrip")
   - `BaseParserBackend`: Instance of a parser backend
   - `Type[BaseParserBackend]`: Class of a parser backend (will be instantiated)
   - Defaults to `"pyyaml"` if `None`
@@ -238,20 +238,20 @@ parser = OpenAPIParser("pyyaml")
 doc = parser.parse(content)
 ```
 
-### ruamel
+### ruamel-safe
 ruamel.yaml-based parser with safe loading. Provides better YAML 1.2 support than PyYAML.
 
-**Accepts:** `text` (JSON/YAML strings)
+**Accepts:** `text` (JSON/YAML strings), `uri` (file paths/URLs)
 
 ```python
-parser = OpenAPIParser("ruamel")
+parser = OpenAPIParser("ruamel-safe")
 doc = parser.parse(content)
 ```
 
 ### ruamel-roundtrip
 ruamel.yaml roundtrip mode that preserves comments, formatting, and provides line/column information.
 
-**Accepts:** `text` (JSON/YAML strings)
+**Accepts:** `text` (JSON/YAML strings), `uri` (file paths/URLs)
 
 ```python
 from ruamel.yaml import CommentedMap

--- a/packages/jentic-openapi-parser/pyproject.toml
+++ b/packages/jentic-openapi-parser/pyproject.toml
@@ -31,6 +31,6 @@ build-backend = "uv_build"
 [project.entry-points."jentic.apitools.openapi.parser.backends"]
 base = "jentic.apitools.openapi.parser.backends.base:BaseParserBackend"
 pyyaml = "jentic.apitools.openapi.parser.backends.pyyaml:PyYAMLParserBackend"
-ruamel = "jentic.apitools.openapi.parser.backends.ruamel:RuamelParserBackend"
+ruamel-safe = "jentic.apitools.openapi.parser.backends.ruamel_safe:RuamelSafeParserBackend"
 ruamel-roundtrip = "jentic.apitools.openapi.parser.backends.ruamel_roundtrip:RuamelRoundTripParserBackend"
 

--- a/packages/jentic-openapi-parser/src/jentic/apitools/openapi/parser/backends/ruamel_roundtrip.py
+++ b/packages/jentic-openapi-parser/src/jentic/apitools/openapi/parser/backends/ruamel_roundtrip.py
@@ -1,9 +1,9 @@
-from jentic.apitools.openapi.parser.backends.ruamel import RuamelParserBackend
+from jentic.apitools.openapi.parser.backends.ruamel_safe import RuamelSafeParserBackend
 
 
 __all__ = ["RuamelRoundTripParserBackend"]
 
 
-class RuamelRoundTripParserBackend(RuamelParserBackend):
+class RuamelRoundTripParserBackend(RuamelSafeParserBackend):
     def __init__(self, pure: bool = True):
         super().__init__(typ="rt", pure=pure)

--- a/packages/jentic-openapi-parser/src/jentic/apitools/openapi/parser/backends/ruamel_safe.py
+++ b/packages/jentic-openapi-parser/src/jentic/apitools/openapi/parser/backends/ruamel_safe.py
@@ -9,10 +9,10 @@ from jentic.apitools.openapi.parser.backends.base import BaseParserBackend
 from jentic.apitools.openapi.parser.core.uri import is_uri_like, load_uri
 
 
-__all__ = ["RuamelParserBackend"]
+__all__ = ["RuamelSafeParserBackend"]
 
 
-class RuamelParserBackend(BaseParserBackend):
+class RuamelSafeParserBackend(BaseParserBackend):
     def __init__(self, typ: str = "safe", pure: bool = True):
         self.yaml = YAML(typ=typ, pure=pure)
         self.yaml.default_flow_style = False

--- a/packages/jentic-openapi-parser/tests/conftest.py
+++ b/packages/jentic-openapi-parser/tests/conftest.py
@@ -39,8 +39,8 @@ def parser_pyyaml() -> OpenAPIParser:
 
 @pytest.fixture
 def parser_ruamel() -> OpenAPIParser:
-    """An OpenAPIParser instance with ruamel backend."""
-    return OpenAPIParser("ruamel")
+    """An OpenAPIParser instance with ruamel-safe backend."""
+    return OpenAPIParser("ruamel-safe")
 
 
 @pytest.fixture

--- a/packages/jentic-openapi-parser/tests/test_parse.py
+++ b/packages/jentic-openapi-parser/tests/test_parse.py
@@ -62,9 +62,9 @@ def test_parse_pyyaml_backend(parser_pyyaml: OpenAPIParser, simple_openapi_strin
 
 
 def test_parse_ruamel_backend(parser_ruamel: OpenAPIParser, simple_openapi_string: str):
-    """Test ruamel parser backend."""
+    """Test ruamel-safe parser backend."""
     backend_name = type(parser_ruamel.backend).__name__
-    assert backend_name == "RuamelParserBackend"
+    assert backend_name == "RuamelSafeParserBackend"
 
     doc = parser_ruamel.parse(simple_openapi_string)
     assert doc["openapi"] == "3.1.0"
@@ -175,8 +175,9 @@ def test_backend_accepts_method():
     parser_pyyaml = OpenAPIParser("pyyaml")
     assert "text" in parser_pyyaml.backend.accepts()
 
-    parser_ruamel = OpenAPIParser("ruamel")
+    parser_ruamel = OpenAPIParser("ruamel-safe")
     assert "text" in parser_ruamel.backend.accepts()
+    assert "uri" in parser_ruamel.backend.accepts()
 
     parser_roundtrip = OpenAPIParser("ruamel-roundtrip")
     assert "text" in parser_roundtrip.backend.accepts()


### PR DESCRIPTION
The parser backend name was conflicting with the vendor library name.