### PR TITLE
fix(validator): fix DataFieldValue type hint

### DIFF
--- a/packages/jentic-openapi-validator/src/jentic/apitools/openapi/validator/core/diagnostics.py
+++ b/packages/jentic-openapi-validator/src/jentic/apitools/openapi/validator/core/diagnostics.py
@@ -1,11 +1,12 @@
 from dataclasses import dataclass, field
+from typing import TypeAlias
 
 from lsprotocol.types import Diagnostic
 
 
 __all__ = ["JenticDiagnostic", "ValidationResult", "DataFieldValue"]
 
-DataFieldValue = (
+DataFieldValue: TypeAlias = (
     None | str | int | float | bool | dict[str, "DataFieldValue"] | list["DataFieldValue"]
 )
 


### PR DESCRIPTION
1. DataFieldValue is a recursive type - it references itself inside dict[str, "DataFieldValue"] and list["DataFieldValue"]
2. Python's type checkers (like PyCharm's or mypy) need recursive type aliases to be explicitly declared using TypeAlias from the typing module
3. Without the TypeAlias annotation, the type checker treats it as a regular variable assignment and gets confused by the forward reference to itself

  The fix:
  - Import TypeAlias from typing
  - Change DataFieldValue = ... to DataFieldValue: TypeAlias = ...

  This tells the type checker "this is a type alias definition" and allows it to properly handle the recursive references. The error should now be resolved in your IDE at line 44 (and anywhere else DataFieldValue is used as
  a type hint).
