### PR TITLE
fix(validator): report missing servers from default validator as error

### DIFF
--- a/packages/jentic-openapi-validator/src/jentic/apitools/openapi/validator/backends/default/__init__.py
+++ b/packages/jentic-openapi-validator/src/jentic/apitools/openapi/validator/backends/default/__init__.py
@@ -17,7 +17,7 @@ from ...core.diagnostics import JenticDiagnostic, ValidationResult
 from ..base import BaseValidatorBackend
 from .rules import RuleRegistry
 from .rules.security import SecuritySchemeReferenceRule, UnusedSecuritySchemeRule
-from .rules.server import ServerUrlRule
+from .rules.server import ServersArrayRule, ServerUrlRule
 from .rules.structural import InfoObjectRule, PathsRule
 
 
@@ -194,7 +194,8 @@ class DefaultOpenAPIValidatorBackend(BaseValidatorBackend):
         registry.register(InfoObjectRule())
         registry.register(PathsRule())
 
-        # Register server rules (only validate format if servers exist)
+        # Register server rules
+        registry.register(ServersArrayRule())
         registry.register(ServerUrlRule())
 
         # Register security rules

--- a/packages/jentic-openapi-validator/tests/conftest.py
+++ b/packages/jentic-openapi-validator/tests/conftest.py
@@ -108,7 +108,7 @@ def validator() -> OpenAPIValidator:
 @pytest.fixture
 def valid_openapi_string() -> str:
     """A valid OpenAPI document as JSON string."""
-    return '{"openapi":"3.1.0","info":{"title":"Test API","version":"1.0.0"},"paths":{}}'
+    return '{"openapi":"3.1.0","info":{"title":"Test API","version":"1.0.0"},"paths":{},"servers":[{"url":"https://api.example.com"}]}'
 
 
 @pytest.fixture
@@ -120,7 +120,12 @@ def invalid_openapi_string() -> str:
 @pytest.fixture
 def valid_openapi_dict() -> dict:
     """A valid OpenAPI document as dictionary."""
-    return {"openapi": "3.1.0", "info": {"title": "Test API", "version": "1.0.0"}, "paths": {}}
+    return {
+        "openapi": "3.1.0",
+        "info": {"title": "Test API", "version": "1.0.0"},
+        "paths": {},
+        "servers": [{"url": "https://api.example.com"}],
+    }
 
 
 @pytest.fixture

--- a/packages/jentic-openapi-validator/tests/test_validate_default.py
+++ b/packages/jentic-openapi-validator/tests/test_validate_default.py
@@ -16,10 +16,6 @@ def test_validator_ok():
     """Test validation of valid OpenAPI documents."""
     val = OpenAPIValidator()
 
-    # Valid document without servers (servers is optional)
-    res = val.validate('{"openapi":"3.1.0","info":{"title":"ok","version":"1"}, "paths": {}}')
-    assert res.valid is True
-
     # Valid document with servers
     res = val.validate(
         '{"openapi":"3.1.0","info":{"title":"ok","version":"1"}, "paths": {}, "servers": [{"url": "https://api.example.com"}]}'
@@ -38,6 +34,11 @@ def test_validator_failure():
     # Invalid version field type (number instead of string)
     res = val.validate('{"openapi":"3.1.0","info":{"title":"ok","version":1}}')
     assert res.valid is False
+
+    # Missing required servers array
+    res = val.validate('{"openapi":"3.1.0","info":{"title":"ok","version":"1"}, "paths": {}}')
+    assert res.valid is False
+    assert any(d.code == "MISSING_SERVER_URL" for d in res.diagnostics)
 
 
 def test_missing_info_section():
@@ -88,6 +89,7 @@ def test_security_scheme_validation():
         "openapi": "3.1.0",
         "info": {"title": "Test", "version": "1.0"},
         "paths": {},
+        "servers": [{"url": "https://api.example.com"}],
         "components": {
             "securitySchemes": {
                 "bearerAuth": {"type": "http", "scheme": "bearer"}


### PR DESCRIPTION
I forgot the register the `ServersArrayRule` when wiring up the default validator. This PR remedies the situation.