### PR TITLE
fix(validator-spectral): collect diagnostics to temp output file

### DIFF
--- a/packages/jentic-openapi-validator-spectral/src/jentic/apitools/openapi/validator/backends/spectral/__init__.py
+++ b/packages/jentic-openapi-validator-spectral/src/jentic/apitools/openapi/validator/backends/spectral/__init__.py
@@ -178,9 +178,7 @@ class SpectralValidatorBackend(BaseValidatorBackend):
         except FileNotFoundError:
             if result.stderr:
                 raise RuntimeError(f"Spectral did not create output file: {result.stderr.strip()}")
-            logger.warning(
-                f"Spectral output file not found at {output_path}, returning empty diagnostics"
-            )
+            logger.warning("Spectral output file not found, returning empty diagnostics")
             return ValidationResult(diagnostics=[])
         except json.JSONDecodeError as e:
             if result.stderr:


### PR DESCRIPTION
This change avoids hitting stdout buffer
size limitations (65536 bytes) when spectral
creates a lot of diagnostics.