### PR TITLE
fix(redocly-validator): collect diagnostics to temp output file

### DIFF
--- a/packages/jentic-openapi-validator-spectral/src/jentic/apitools/openapi/validator/backends/spectral/__init__.py
+++ b/packages/jentic-openapi-validator-spectral/src/jentic/apitools/openapi/validator/backends/spectral/__init__.py
@@ -142,53 +142,60 @@ class SpectralValidatorBackend(BaseValidatorBackend):
             with tempfile.NamedTemporaryFile() as tmp_output:
                 output_path = tmp_output.name
 
-            with as_file(ruleset_file) as default_ruleset_path:
-                # Build spectral command
-                cmd = [
-                    *shlex.split(self.spectral_path),
-                    "lint",
-                    "-r",
-                    validated_ruleset_path or default_ruleset_path,
-                    "-f",
-                    "json",
-                    "-o",
-                    output_path,
-                    validated_doc_path,
-                ]
-                result = run_subprocess(cmd, timeout=self.timeout)
+            try:
+                with as_file(ruleset_file) as default_ruleset_path:
+                    # Build spectral command
+                    cmd = [
+                        *shlex.split(self.spectral_path),
+                        "lint",
+                        "-r",
+                        validated_ruleset_path or default_ruleset_path,
+                        "-f",
+                        "json",
+                        "-o",
+                        output_path,
+                        validated_doc_path,
+                    ]
+                    result = run_subprocess(cmd, timeout=self.timeout)
+
+                if result is None:
+                    raise RuntimeError("Spectral validation failed - no result returned")
+
+                # Check for execution errors
+                if result.returncode not in (0, 1):
+                    # According to Spectral docs, return code 2 might indicate lint errors found,
+                    # 0 means no issues, but let's not assume this; we'll parse output.
+                    # If returncode is something else, spectral encountered an execution error.
+                    msg = result.stderr.strip() or f"Spectral exited with code {result.returncode}"
+                    raise RuntimeError(msg)
+
+                # Read and parse output file
+                try:
+                    with open(output_path, encoding="utf-8") as f:
+                        issues: list[dict] = json.load(f)
+                except FileNotFoundError:
+                    if result.stderr:
+                        raise RuntimeError(
+                            f"Spectral did not create output file: {result.stderr.strip()}"
+                        )
+                    logger.warning("Spectral output file not found, returning empty diagnostics")
+                    return ValidationResult(diagnostics=[])
+                except json.JSONDecodeError as e:
+                    if result.stderr:
+                        raise RuntimeError(
+                            f"Spectral output is not valid JSON: {result.stderr.strip()}"
+                        )
+                    logger.warning(
+                        f"Spectral output is not valid JSON: {e}, returning empty diagnostics"
+                    )
+                    return ValidationResult(diagnostics=[])
+            finally:
+                # Clean up the temp output file
+                Path(output_path).unlink(missing_ok=True)
 
         except SubprocessExecutionError as e:
             # only timeout and OS errors, as run_subprocess has a default `fail_on_error = False`
             raise e
-
-        if result is None:
-            raise RuntimeError("Spectral validation failed - no result returned")
-
-        # Check for execution errors
-        if result.returncode not in (0, 1):
-            # According to Spectral docs, return code 2 might indicate lint errors found,
-            # 0 means no issues, but let's not assume this; we'll parse output.
-            # If returncode is something else, spectral encountered an execution error.
-            msg = result.stderr.strip() or f"Spectral exited with code {result.returncode}"
-            raise RuntimeError(msg)
-
-        # Read and parse output file
-        try:
-            with open(output_path, encoding="utf-8") as f:
-                issues: list[dict] = json.load(f)
-        except FileNotFoundError:
-            if result.stderr:
-                raise RuntimeError(f"Spectral did not create output file: {result.stderr.strip()}")
-            logger.warning("Spectral output file not found, returning empty diagnostics")
-            return ValidationResult(diagnostics=[])
-        except json.JSONDecodeError as e:
-            if result.stderr:
-                raise RuntimeError(f"Spectral output is not valid JSON: {result.stderr.strip()}")
-            logger.warning(f"Spectral output is not valid JSON: {e}, returning empty diagnostics")
-            return ValidationResult(diagnostics=[])
-        finally:
-            # Clean up the temp output file
-            Path(output_path).unlink(missing_ok=True)
 
         diagnostics: list[JenticDiagnostic] = []
         for issue in issues:


### PR DESCRIPTION
This change avoids hitting stdout buffer
size limitations (65536 bytes) when Redocly
creates a lot of diagnostics.