### PR TITLE
feat(transformer): enhance `count_references` with `refs_only` support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -322,7 +322,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -1356,7 +1355,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -3202,7 +3200,6 @@
       "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -3464,7 +3461,6 @@
       "resolved": "https://registry.npmjs.org/mobx/-/mobx-6.15.0.tgz",
       "integrity": "sha512-UczzB+0nnwGotYSgllfARAqWCJ5e/skuV2K/l+Zyck/H6pJIhLXuBnz+6vn2i211o7DtbE78HQtsYEKICHGI+g==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mobx"
@@ -4034,7 +4030,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4044,7 +4039,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -4291,7 +4285,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz",
       "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -4875,7 +4868,6 @@
       "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.1.19.tgz",
       "integrity": "sha512-1v/e3Dl1BknC37cXMhwGomhO8AkYmN41CqyX9xhUDxry1ns3BFQy2lLDRQXJRdVVWB9OHemv/53xaStimvWyuA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emotion/is-prop-valid": "1.2.2",
         "@emotion/unitless": "0.8.1",

--- a/packages/jentic-openapi-transformer/tests/references/test_count_references.py
+++ b/packages/jentic-openapi-transformer/tests/references/test_count_references.py
@@ -1,0 +1,332 @@
+"""Tests for count_references function."""
+
+from jentic.apitools.openapi.transformer.core.references import count_references
+
+
+class TestCountReferences:
+    """Tests for count_references function with refs_only=False."""
+
+    def test_count_references_simple(self):
+        """Test counting references in simple document."""
+        doc = {
+            "openapi": "3.1.0",
+            "info": {
+                "title": "Test",
+                "version": "1.0.0",
+                "contact": {"url": "https://example.com/contact"},
+            },
+            "externalDocs": {"url": "./docs.html"},
+            "paths": {
+                "/test": {
+                    "get": {
+                        "responses": {
+                            "200": {
+                                "content": {
+                                    "application/json": {
+                                        "schema": {"$ref": "#/components/schemas/User"}
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+        }
+
+        total, local_refs, relative_refs, absolute_http_refs = count_references(doc)
+
+        # total should include: contact.url (absolute), externalDocs.url (relative), $ref (local)
+        assert total == 3
+        assert local_refs == 1  # The fragment-only $ref
+        assert relative_refs == 1  # The ./docs.html
+        assert absolute_http_refs == 1  # The https:// URL
+
+    def test_count_references_mixed_types(self):
+        """Test counting various types of references."""
+        doc = {
+            "openapi": "3.0.3",
+            "info": {
+                "title": "Test",
+                "version": "1.0.0",
+                "contact": {"url": "/contact"},  # relative
+                "license": {"url": "https://opensource.org/licenses/MIT"},  # absolute HTTP
+            },
+            "externalDocs": {"url": "./docs.html"},  # relative
+            "components": {
+                "schemas": {
+                    "User": {"$ref": "#/components/schemas/Base"},  # local
+                    "Item": {"$ref": "./schemas/item.json"},  # relative
+                    "Remote": {
+                        "$ref": "https://api.example.com/schemas/remote.json"
+                    },  # absolute HTTP
+                },
+                "examples": {
+                    "example1": {"externalValue": "../examples/test.json"}  # relative
+                },
+            },
+        }
+
+        total, local_refs, relative_refs, absolute_http_refs = count_references(doc)
+
+        # total: /contact, license.url, externalDocs.url, 3 $refs, externalValue = 7
+        assert total == 7
+        assert local_refs == 1  # The fragment-only $ref
+        assert (
+            relative_refs == 4
+        )  # /contact, ./docs.html, ./schemas/item.json, ../examples/test.json
+        assert absolute_http_refs == 2  # license.url and Remote $ref
+
+    def test_count_references_empty_document(self):
+        """Test counting references in empty document."""
+        doc = {}
+
+        total, local_refs, relative_refs, absolute_http_refs = count_references(doc)
+
+        assert total == 0
+        assert local_refs == 0
+        assert relative_refs == 0
+        assert absolute_http_refs == 0
+
+    def test_count_references_no_refs(self):
+        """Test document with no references."""
+        doc = {
+            "openapi": "3.1.0",
+            "info": {
+                "title": "Test",
+                "version": "1.0.0",
+                "description": "A test API",
+            },
+            "paths": {},
+        }
+
+        total, local_refs, relative_refs, absolute_http_refs = count_references(doc)
+
+        assert total == 0
+        assert local_refs == 0
+        assert relative_refs == 0
+        assert absolute_http_refs == 0
+
+    def test_count_references_only_local(self):
+        """Test document with only local (fragment-only) references."""
+        doc = {
+            "openapi": "3.1.0",
+            "info": {"title": "Test", "version": "1.0.0"},
+            "paths": {
+                "/test": {
+                    "get": {
+                        "responses": {
+                            "200": {
+                                "content": {
+                                    "application/json": {
+                                        "schema": {"$ref": "#/components/schemas/User"}
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "components": {
+                "schemas": {
+                    "User": {
+                        "type": "object",
+                        "properties": {"id": {"$ref": "#/components/schemas/Id"}},
+                    }
+                }
+            },
+        }
+
+        total, local_refs, relative_refs, absolute_http_refs = count_references(doc)
+
+        assert total == 2
+        assert local_refs == 2
+        assert relative_refs == 0
+        assert absolute_http_refs == 0
+
+    def test_count_references_oauth_urls(self):
+        """Test counting OAuth and OpenID Connect URLs."""
+        doc = {
+            "openapi": "3.0.3",
+            "info": {"title": "Test", "version": "1.0.0"},
+            "components": {
+                "securitySchemes": {
+                    "oauth": {
+                        "type": "oauth2",
+                        "flows": {
+                            "authorizationCode": {
+                                "authorizationUrl": "https://auth.example.com/oauth/authorize",
+                                "tokenUrl": "https://auth.example.com/oauth/token",
+                                "refreshUrl": "https://auth.example.com/oauth/refresh",
+                            }
+                        },
+                    },
+                    "openid": {
+                        "type": "openIdConnect",
+                        "openIdConnectUrl": "https://auth.example.com/.well-known/openid-configuration",
+                    },
+                }
+            },
+        }
+
+        total, local_refs, relative_refs, absolute_http_refs = count_references(doc)
+
+        assert total == 4
+        assert local_refs == 0
+        assert relative_refs == 0
+        assert absolute_http_refs == 4
+
+
+class TestCountReferencesRefsOnly:
+    """Tests for count_references function with refs_only=True."""
+
+    def test_count_references_refs_only_simple(self):
+        """Test counting only $ref fields."""
+        doc = {
+            "openapi": "3.1.0",
+            "info": {
+                "title": "Test",
+                "version": "1.0.0",
+                "contact": {"url": "https://example.com/contact"},  # Should NOT be counted
+            },
+            "externalDocs": {"url": "./docs.html"},  # Should NOT be counted
+            "paths": {
+                "/test": {
+                    "get": {
+                        "responses": {
+                            "200": {
+                                "content": {
+                                    "application/json": {
+                                        "schema": {
+                                            "$ref": "#/components/schemas/User"
+                                        }  # Should be counted
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+        }
+
+        total, local_refs, relative_refs, absolute_http_refs = count_references(doc, refs_only=True)
+
+        # Should only count the $ref
+        assert total == 1
+        assert local_refs == 1
+        assert relative_refs == 0
+        assert absolute_http_refs == 0
+
+    def test_count_references_refs_only_mixed(self):
+        """Test counting only $refs in document with mixed URL types."""
+        doc = {
+            "openapi": "3.0.3",
+            "info": {
+                "title": "Test",
+                "version": "1.0.0",
+                "contact": {"url": "/contact"},  # Should NOT be counted
+                "license": {"url": "https://opensource.org/licenses/MIT"},  # Should NOT be counted
+            },
+            "externalDocs": {"url": "./docs.html"},  # Should NOT be counted
+            "components": {
+                "schemas": {
+                    "User": {"$ref": "#/components/schemas/Base"},  # local - should be counted
+                    "Item": {"$ref": "./schemas/item.json"},  # relative - should be counted
+                    "Remote": {
+                        "$ref": "https://api.example.com/schemas/remote.json"
+                    },  # absolute HTTP - should be counted
+                },
+                "examples": {
+                    "example1": {"externalValue": "../examples/test.json"}  # Should NOT be counted
+                },
+            },
+        }
+
+        total, local_refs, relative_refs, absolute_http_refs = count_references(doc, refs_only=True)
+
+        # Should only count the 3 $refs
+        assert total == 3
+        assert local_refs == 1  # The fragment-only $ref
+        assert relative_refs == 1  # ./schemas/item.json
+        assert absolute_http_refs == 1  # Remote $ref
+
+    def test_count_references_refs_only_no_refs(self):
+        """Test document with no $refs but other URL fields."""
+        doc = {
+            "openapi": "3.1.0",
+            "info": {
+                "title": "Test",
+                "version": "1.0.0",
+                "contact": {"url": "./contact.html"},
+                "license": {"url": "https://opensource.org/licenses/MIT"},
+            },
+            "externalDocs": {"url": "./docs.html"},
+        }
+
+        total, local_refs, relative_refs, absolute_http_refs = count_references(doc, refs_only=True)
+
+        # No $refs, so all counts should be 0
+        assert total == 0
+        assert local_refs == 0
+        assert relative_refs == 0
+        assert absolute_http_refs == 0
+
+    def test_count_references_refs_only_ignore_oauth(self):
+        """Test that OAuth URLs are not counted with refs_only=True."""
+        doc = {
+            "openapi": "3.0.3",
+            "info": {"title": "Test", "version": "1.0.0"},
+            "components": {
+                "securitySchemes": {
+                    "oauth": {
+                        "type": "oauth2",
+                        "flows": {
+                            "authorizationCode": {
+                                "authorizationUrl": "https://auth.example.com/oauth/authorize",
+                                "tokenUrl": "https://auth.example.com/oauth/token",
+                            }
+                        },
+                    }
+                },
+                "schemas": {
+                    "User": {"$ref": "./user.json"}  # This should be counted
+                },
+            },
+        }
+
+        total, local_refs, relative_refs, absolute_http_refs = count_references(doc, refs_only=True)
+
+        # Should only count the $ref, not the OAuth URLs
+        assert total == 1
+        assert local_refs == 0
+        assert relative_refs == 1
+        assert absolute_http_refs == 0
+
+    def test_count_references_refs_only_all_types(self):
+        """Test counting all types of $refs with refs_only=True."""
+        doc = {
+            "openapi": "3.1.0",
+            "info": {"title": "Test", "version": "1.0.0"},
+            "components": {
+                "schemas": {
+                    "Local": {"$ref": "#/components/schemas/Base"},  # local
+                    "Relative1": {"$ref": "./schemas/user.json"},  # relative
+                    "Relative2": {"$ref": "../common/item.json"},  # relative
+                    "RootRelative": {
+                        "$ref": "/schemas/root.json"
+                    },  # root-relative (still relative)
+                    "AbsoluteHttp": {
+                        "$ref": "https://api.example.com/schemas/remote.json"
+                    },  # absolute HTTP
+                    "AbsoluteHttps": {
+                        "$ref": "https://api.example.com/schemas/other.json"
+                    },  # absolute HTTPS
+                }
+            },
+        }
+
+        total, local_refs, relative_refs, absolute_http_refs = count_references(doc, refs_only=True)
+
+        assert total == 6
+        assert local_refs == 1  # #/components/schemas/Base
+        assert relative_refs == 3  # ./schemas/user.json, ../common/item.json, /schemas/root.json
+        assert absolute_http_refs == 2  # The two https:// $refs

--- a/packages/jentic-openapi-transformer/tests/references/test_edge_cases.py
+++ b/packages/jentic-openapi-transformer/tests/references/test_edge_cases.py
@@ -117,3 +117,182 @@ class TestEdgeCases:
         opts = RewriteOptions(base_url="https://example.com/")
         changed = rewrite_urls_inplace(doc, opts)
         assert changed == 0
+
+
+class TestEdgeCasesRefsOnly:
+    """Tests for edge cases and error conditions with refs_only=True."""
+
+    def test_nested_arrays_and_objects_refs_only(self):
+        """Test finding URLs in deeply nested structures with refs_only=True."""
+        doc = {
+            "openapi": "3.1.0",
+            "info": {"title": "Test", "version": "1.0.0"},
+            "paths": {
+                "/test": {
+                    "get": {
+                        "responses": {
+                            "200": {
+                                "content": {
+                                    "application/json": {
+                                        "schema": {
+                                            "oneOf": [
+                                                {"$ref": "./schema1.json#/Type1"},
+                                                {"$ref": "./schema2.json#/Type2"},
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+        }
+
+        relative_urls = find_relative_urls(doc, refs_only=True)
+        assert len(relative_urls) == 2
+
+        values = [url[2] for url in relative_urls]
+        assert "./schema1.json#/Type1" in values
+        assert "./schema2.json#/Type2" in values
+
+    def test_url_like_strings_in_descriptions_refs_only(self):
+        """Test that only $ref fields are processed with refs_only=True."""
+        doc = {
+            "openapi": "3.1.0",
+            "info": {
+                "title": "Test",
+                "version": "1.0.0",
+                "description": "See ./docs/api.md for more info",  # Not a URL field
+            },
+            "paths": {
+                "/test": {
+                    "get": {
+                        "summary": "Check ../examples/test.json",  # Not a URL field
+                        "externalDocs": {
+                            "url": "./real-docs.html"  # This is a URL field but NOT $ref
+                        },
+                    }
+                }
+            },
+        }
+
+        relative_urls = find_relative_urls(doc, refs_only=True)
+
+        # Should NOT find any URLs since there are no $ref fields
+        assert len(relative_urls) == 0
+
+    def test_refs_and_other_urls_refs_only(self):
+        """Test that with refs_only=True, only $ref fields are found, not other URL fields."""
+        doc = {
+            "openapi": "3.1.0",
+            "info": {"title": "Test", "version": "1.0.0"},
+            "externalDocs": {
+                "url": "./docs.html"  # URL field but NOT $ref
+            },
+            "components": {
+                "schemas": {
+                    "User": {
+                        "$ref": "./user-schema.json#/User"  # This is $ref
+                    }
+                },
+                "examples": {
+                    "example1": {
+                        "externalValue": "./example.json"  # URL field but NOT $ref
+                    }
+                },
+            },
+        }
+
+        relative_urls = find_relative_urls(doc, refs_only=True)
+
+        # Should only find the $ref field
+        assert len(relative_urls) == 1
+        assert relative_urls[0][1] == "$ref"
+        assert relative_urls[0][2] == "./user-schema.json#/User"
+
+    def test_empty_and_whitespace_urls_refs_only(self):
+        """Test handling of empty and whitespace-only $ref values with refs_only=True."""
+        doc = {
+            "openapi": "3.1.0",
+            "info": {"title": "Test", "version": "1.0.0"},
+            "components": {
+                "schemas": {
+                    "Empty": {
+                        "$ref": ""  # Empty string
+                    },
+                    "Whitespace": {
+                        "$ref": "   "  # Whitespace only
+                    },
+                }
+            },
+        }
+
+        relative_urls = find_relative_urls(doc, refs_only=True)
+
+        # Empty and whitespace-only $refs should be ignored
+        assert len(relative_urls) == 0
+
+    def test_non_string_values_in_ref_fields_refs_only(self):
+        """Test that non-string values in $ref fields are ignored with refs_only=True."""
+        doc = {
+            "openapi": "3.1.0",
+            "info": {"title": "Test", "version": "1.0.0"},
+            "components": {
+                "schemas": {
+                    "Number": {
+                        "$ref": 123  # Number instead of string
+                    },
+                    "NullRef": {
+                        "$ref": None  # None instead of string
+                    },
+                }
+            },
+        }
+
+        relative_urls = find_relative_urls(doc, refs_only=True)
+        assert len(relative_urls) == 0
+
+        # rewrite_urls_inplace should not crash and should not change anything
+        opts = RewriteOptions(base_url="https://example.com/", refs_only=True)
+        changed = rewrite_urls_inplace(doc, opts)
+        assert changed == 0
+
+    def test_rewrite_urls_refs_only(self):
+        """Test that rewrite_urls_inplace with refs_only=True only rewrites $ref fields."""
+        doc = {
+            "openapi": "3.1.0",
+            "info": {
+                "title": "Test",
+                "version": "1.0.0",
+                "contact": {"url": "./contact.html"},  # Should NOT be rewritten
+            },
+            "externalDocs": {"url": "./docs.html"},  # Should NOT be rewritten
+            "components": {
+                "schemas": {
+                    "User": {
+                        "$ref": "./user.json#/User"  # Should be rewritten
+                    }
+                },
+                "examples": {
+                    "example1": {
+                        "externalValue": "./example.json"  # Should NOT be rewritten
+                    }
+                },
+            },
+        }
+
+        opts = RewriteOptions(base_url="https://api.example.com/", refs_only=True)
+        changed = rewrite_urls_inplace(doc, opts)
+
+        # Should only change the $ref field
+        assert changed == 1
+        assert (
+            doc["components"]["schemas"]["User"]["$ref"]
+            == "https://api.example.com/user.json#/User"
+        )
+
+        # Other URL fields should remain unchanged
+        assert doc["info"]["contact"]["url"] == "./contact.html"
+        assert doc["externalDocs"]["url"] == "./docs.html"
+        assert doc["components"]["examples"]["example1"]["externalValue"] == "./example.json"

--- a/packages/jentic-openapi-transformer/tests/references/test_references.py
+++ b/packages/jentic-openapi-transformer/tests/references/test_references.py
@@ -89,3 +89,107 @@ def test_references_retarget_absolute_urls(root_relative_refs_doc: Any) -> None:
     # Check that some $ref was also retargeted
     spec_text = json_dumps(spec_doc)
     assert "https://new.example.com/v2/" in spec_text, "Document should contain retargeted URLs"
+
+
+def test_references_refs_only(root_relative_refs_doc: Any) -> None:
+    """Test reference processing with refs_only=True.
+
+    Tests:
+    - Finding only $ref fields in OpenAPI documents
+    - Rewriting only $ref fields to absolute URLs
+    - Verifying other URL fields are not affected
+    """
+    spec_doc = root_relative_refs_doc
+
+    # Add some non-$ref URL fields to test
+    spec_doc["info"]["contact"] = {"url": "./contact.html"}
+    spec_doc["externalDocs"] = {"url": "./docs.html"}
+
+    # Test find_relative_urls with refs_only=True
+    relative_urls_refs_only = find_relative_urls(spec_doc, refs_only=True)
+    relative_urls_all = find_relative_urls(spec_doc, refs_only=False)
+
+    # Should find fewer URLs with refs_only=True
+    assert len(relative_urls_refs_only) < len(relative_urls_all), (
+        "refs_only=True should find fewer URLs than refs_only=False"
+    )
+
+    # Verify that only $ref fields are in the refs_only list
+    for json_path, key, value in relative_urls_refs_only:
+        assert key == "$ref", f"With refs_only=True, should only find $ref fields, but found: {key}"
+
+    # Test rewrite_urls_inplace with refs_only=True
+    base_url = "http://localhost:8080/root-relative-refs.json"
+    opts = RewriteOptions(
+        base_url=base_url,
+        original_base_url=base_url,
+        include_absolute_urls=False,
+        refs_only=True,
+    )
+    changed = rewrite_urls_inplace(spec_doc, opts)
+
+    assert changed > 0, "Should have rewritten some $ref URLs"
+    assert changed == len(relative_urls_refs_only), (
+        f"Should have rewritten all {len(relative_urls_refs_only)} $ref URLs, but changed {changed}"
+    )
+
+    # Verify that $refs were rewritten but other URL fields were not
+    assert spec_doc["info"]["contact"]["url"] == "./contact.html", (
+        "Non-$ref URL fields should not be affected"
+    )
+    assert spec_doc["externalDocs"]["url"] == "./docs.html", (
+        "Non-$ref URL fields should not be affected"
+    )
+
+    # Verify that $refs were actually rewritten to absolute
+    new_relative_refs = find_relative_urls(spec_doc, refs_only=True)
+    assert len(new_relative_refs) == 0, "After rewriting, there should be no relative $refs left"
+
+
+def test_references_retarget_absolute_urls_refs_only(root_relative_refs_doc: Any) -> None:
+    """Test retargeting absolute $ref URLs with refs_only=True.
+
+    This test verifies that when refs_only=True, include_absolute_urls=True and
+    original_base_url is specified, only absolute $ref URLs are retargeted,
+    not other URL fields.
+    """
+    spec_doc = root_relative_refs_doc
+
+    # First make some $refs absolute with original base
+    opts1 = RewriteOptions(base_url="http://old.example.com/api/", refs_only=True)
+    rewrite_urls_inplace(spec_doc, opts1)
+
+    # Add some non-$ref URL fields with the old base
+    spec_doc["info"]["termsOfService"] = "http://old.example.com/api/terms.html"
+    spec_doc["info"]["contact"] = {"url": "http://old.example.com/api/contact.html"}
+
+    # Add an absolute $ref that matches the original base
+    spec_doc["components"] = spec_doc.get("components", {})
+    spec_doc["components"]["schemas"] = spec_doc["components"].get("schemas", {})
+    spec_doc["components"]["schemas"]["TestSchema"] = {
+        "$ref": "http://old.example.com/api/schemas/test.json"
+    }
+
+    # Now retarget from old base to new base with refs_only=True
+    opts2 = RewriteOptions(
+        base_url="https://new.example.com/v2/",
+        original_base_url="http://old.example.com/api/",
+        include_absolute_urls=True,
+        refs_only=True,
+    )
+    changed = rewrite_urls_inplace(spec_doc, opts2)
+
+    assert changed > 0, "Should have retargeted some absolute $ref URLs"
+
+    # Verify that non-$ref URL fields were NOT retargeted
+    assert spec_doc["info"]["termsOfService"] == "http://old.example.com/api/terms.html", (
+        "Non-$ref URL fields should not be retargeted with refs_only=True"
+    )
+    assert spec_doc["info"]["contact"]["url"] == "http://old.example.com/api/contact.html", (
+        "Non-$ref URL fields should not be retargeted with refs_only=True"
+    )
+
+    # Verify that the $ref was retargeted
+    assert spec_doc["components"]["schemas"]["TestSchema"]["$ref"] == (
+        "https://new.example.com/v2/schemas/test.json"
+    ), "Absolute $ref URLs should be retargeted"

--- a/packages/jentic-openapi-transformer/tests/references/test_rewrite_urls.py
+++ b/packages/jentic-openapi-transformer/tests/references/test_rewrite_urls.py
@@ -135,3 +135,234 @@ class TestRewriteUrlsInplace:
 
         assert changed == 0
         assert doc["info"]["contact"]["url"] == "https://example.com/contact"
+
+
+class TestRewriteUrlsInplaceRefsOnly:
+    """Tests for rewrite_urls_inplace function with refs_only=True."""
+
+    def test_rewrite_only_refs_to_absolute(self):
+        """Test rewriting only $ref fields to absolute, not other URL fields."""
+        doc = {
+            "openapi": "3.1.0",
+            "info": {
+                "title": "Test",
+                "version": "1.0.0",
+                "contact": {"url": "contact.html"},  # Should NOT be rewritten
+            },
+            "externalDocs": {"url": "./docs.html"},  # Should NOT be rewritten
+            "paths": {
+                "/test": {
+                    "get": {
+                        "responses": {
+                            "200": {
+                                "content": {
+                                    "application/json": {"schema": {"$ref": "./schemas.json#/User"}}
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+        }
+
+        opts = RewriteOptions(base_url="https://api.example.com/v1/", refs_only=True)
+        changed = rewrite_urls_inplace(doc, opts)
+
+        # Should only change the $ref field
+        assert changed == 1
+        assert (
+            doc["paths"]["/test"]["get"]["responses"]["200"]["content"]["application/json"][
+                "schema"
+            ]["$ref"]
+            == "https://api.example.com/v1/schemas.json#/User"
+        )
+
+        # Other URL fields should remain unchanged
+        assert doc["info"]["contact"]["url"] == "contact.html"
+        assert doc["externalDocs"]["url"] == "./docs.html"
+
+    def test_rewrite_multiple_refs_ignore_other_urls(self):
+        """Test rewriting multiple $refs while ignoring other URL fields."""
+        doc = {
+            "openapi": "3.0.3",
+            "info": {
+                "title": "Test",
+                "version": "1.0.0",
+                "contact": {"url": "/api/contact"},  # Should NOT be rewritten
+            },
+            "servers": [{"url": "/api/v1"}],  # Should NOT be rewritten
+            "components": {
+                "schemas": {
+                    "User": {
+                        "$ref": "./schemas/user.json"  # Should be rewritten
+                    },
+                    "Item": {
+                        "$ref": "../common/item.json"  # Should be rewritten
+                    },
+                },
+                "examples": {
+                    "example1": {
+                        "externalValue": "./example.json"  # Should NOT be rewritten
+                    }
+                },
+            },
+        }
+
+        opts = RewriteOptions(base_url="https://api.example.com/", refs_only=True)
+        changed = rewrite_urls_inplace(doc, opts)
+
+        # Should only change the 2 $ref fields
+        assert changed == 2
+        assert (
+            doc["components"]["schemas"]["User"]["$ref"]
+            == "https://api.example.com/schemas/user.json"
+        )
+        assert (
+            doc["components"]["schemas"]["Item"]["$ref"]
+            == "https://api.example.com/common/item.json"
+        )
+
+        # Other URL fields should remain unchanged
+        assert doc["info"]["contact"]["url"] == "/api/contact"
+        assert doc["servers"][0]["url"] == "/api/v1"
+        assert doc["components"]["examples"]["example1"]["externalValue"] == "./example.json"
+
+    def test_retarget_only_absolute_refs(self):
+        """Test retargeting only absolute $ref URLs with refs_only=True."""
+        doc = {
+            "openapi": "3.1.0",
+            "info": {
+                "title": "Test",
+                "version": "1.0.0",
+                "contact": {"url": "https://old.example.com/contact"},  # Should NOT be retargeted
+            },
+            "components": {
+                "schemas": {
+                    "User": {
+                        "$ref": "https://old.example.com/schemas/user.json"  # Should be retargeted
+                    }
+                },
+                "examples": {
+                    "example1": {
+                        "externalValue": "https://old.example.com/examples/test.json"  # Should NOT be retargeted
+                    }
+                },
+            },
+        }
+
+        opts = RewriteOptions(
+            base_url="https://new.example.com/",
+            original_base_url="https://old.example.com/",
+            include_absolute_urls=True,
+            refs_only=True,
+        )
+        changed = rewrite_urls_inplace(doc, opts)
+
+        # Should only change the $ref field
+        assert changed == 1
+        assert (
+            doc["components"]["schemas"]["User"]["$ref"]
+            == "https://new.example.com/schemas/user.json"
+        )
+
+        # Other URL fields should remain unchanged
+        assert doc["info"]["contact"]["url"] == "https://old.example.com/contact"
+        assert (
+            doc["components"]["examples"]["example1"]["externalValue"]
+            == "https://old.example.com/examples/test.json"
+        )
+
+    def test_preserve_fragment_only_refs_with_refs_only(self):
+        """Test that fragment-only $refs are preserved with refs_only=True."""
+        doc = {
+            "openapi": "3.1.0",
+            "info": {"title": "Test", "version": "1.0.0"},
+            "paths": {
+                "/test": {
+                    "get": {
+                        "responses": {
+                            "200": {
+                                "content": {
+                                    "application/json": {
+                                        "schema": {"$ref": "#/components/schemas/User"}
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+        }
+
+        opts = RewriteOptions(base_url="https://api.example.com/", refs_only=True)
+        changed = rewrite_urls_inplace(doc, opts)
+
+        assert changed == 0
+        assert (
+            doc["paths"]["/test"]["get"]["responses"]["200"]["content"]["application/json"][
+                "schema"
+            ]["$ref"]
+            == "#/components/schemas/User"
+        )
+
+    def test_no_changes_when_no_refs(self):
+        """Test that no changes are made when there are no $ref fields with refs_only=True."""
+        doc = {
+            "openapi": "3.1.0",
+            "info": {
+                "title": "Test",
+                "version": "1.0.0",
+                "contact": {"url": "./contact.html"},
+            },
+            "externalDocs": {"url": "docs/api.html"},
+        }
+
+        opts = RewriteOptions(base_url="https://api.example.com/", refs_only=True)
+        changed = rewrite_urls_inplace(doc, opts)
+
+        # No $refs, so nothing should change
+        assert changed == 0
+        assert doc["info"]["contact"]["url"] == "./contact.html"
+        assert doc["externalDocs"]["url"] == "docs/api.html"
+
+    def test_mixed_refs_and_urls(self):
+        """Test document with both $refs and other URL fields, only $refs should be rewritten."""
+        doc = {
+            "openapi": "3.1.0",
+            "info": {
+                "title": "Test API",
+                "version": "1.0.0",
+                "contact": {"url": "./contact"},
+                "license": {"url": "../license.txt"},
+            },
+            "externalDocs": {"url": "/docs"},
+            "servers": [{"url": "https://api.example.com/v1"}],
+            "components": {
+                "schemas": {
+                    "User": {"$ref": "./user.json"},
+                    "Item": {"$ref": "./item.json#/Item"},
+                }
+            },
+        }
+
+        opts = RewriteOptions(base_url="https://new-api.example.com/api/", refs_only=True)
+        changed = rewrite_urls_inplace(doc, opts)
+
+        # Should change only the 2 $refs
+        assert changed == 2
+
+        # Verify $refs were rewritten
+        assert (
+            doc["components"]["schemas"]["User"]["$ref"]
+            == "https://new-api.example.com/api/user.json"
+        )
+        assert (
+            doc["components"]["schemas"]["Item"]["$ref"]
+            == "https://new-api.example.com/api/item.json#/Item"
+        )
+
+        # Verify other URL fields were NOT rewritten
+        assert doc["info"]["contact"]["url"] == "./contact"
+        assert doc["info"]["license"]["url"] == "../license.txt"
+        assert doc["externalDocs"]["url"] == "/docs"
+        assert doc["servers"][0]["url"] == "https://api.example.com/v1"

--- a/packages/jentic-openapi-transformer/tests/references/test_url_loading.py
+++ b/packages/jentic-openapi-transformer/tests/references/test_url_loading.py
@@ -113,3 +113,156 @@ class TestWithHttpUrls:
 
         # Check that absolute URL was retargeted
         assert spec_doc["info"]["termsOfService"] == "https://api.production.com/v1/terms.html"
+
+
+class TestWithFileUrlsRefsOnly:
+    """Tests using file:// URLs to load documents with refs_only=True."""
+
+    def test_load_and_process_from_file_url_refs_only(self, references_fixtures_dir):
+        """Test loading and processing only $refs from file:// URL."""
+        spec_file = references_fixtures_dir / "root-simple.json"
+        spec_uri = spec_file.as_uri()
+        spec_text = load_uri(spec_uri, 300, 300)
+
+        spec_doc = OpenAPIParser().parse(spec_text)
+
+        # Add some non-$ref URL fields
+        spec_doc["info"]["contact"] = {"url": "./contact.html"}
+
+        # Find relative URLs with and without refs_only
+        relative_urls_all = find_relative_urls(spec_doc, refs_only=False)
+        relative_urls_refs = find_relative_urls(spec_doc, refs_only=True)
+
+        assert len(relative_urls_refs) <= len(relative_urls_all)
+
+        # Rewrite only $refs
+        opts = RewriteOptions(base_url=spec_uri, refs_only=True)
+        changed = rewrite_urls_inplace(spec_doc, opts)
+        assert changed == len(relative_urls_refs)
+
+        # Verify non-$ref fields were not changed
+        assert spec_doc["info"]["contact"]["url"] == "./contact.html"
+
+    def test_load_complex_document_from_file_refs_only(self, references_fixtures_dir):
+        """Test loading and processing only $refs from complex document."""
+        spec_file = references_fixtures_dir / "root-complex.json"
+        spec_uri = spec_file.as_uri()
+        spec_text = load_uri(spec_uri, 300, 300)
+
+        spec_doc = OpenAPIParser().parse(spec_text)
+
+        # Find relative $refs only
+        relative_urls_refs = find_relative_urls(spec_doc, refs_only=True)
+        refs_values = [url[2] for url in relative_urls_refs]
+
+        # Should only find $refs, not server URLs
+        for value in refs_values:
+            assert not value.startswith("/api/"), (
+                "Server URLs should not be included with refs_only=True"
+            )
+
+        # Rewrite only $refs
+        opts = RewriteOptions(base_url=spec_uri, refs_only=True)
+        rewrite_urls_inplace(spec_doc, opts)
+
+        # Server URL should still be relative
+        assert spec_doc["servers"][1]["url"] == "/api/v2", (
+            "Server URL should not be changed with refs_only=True"
+        )
+
+
+class TestWithHttpUrlsRefsOnly:
+    """Tests using HTTP URLs to load documents with refs_only=True."""
+
+    def test_load_and_process_from_http_url_refs_only(self, http_server):
+        """Test loading and processing only $refs from HTTP URL."""
+        spec_url = urljoin(http_server.base_url, "root-simple.json")
+        spec_text = load_uri(spec_url, 300, 300)
+
+        spec_doc = OpenAPIParser().parse(spec_text)
+
+        # Add some non-$ref URL fields
+        spec_doc["externalDocs"] = {"url": "./docs.html"}
+
+        # Find relative $refs only
+        relative_refs = find_relative_urls(spec_doc, refs_only=True)
+        assert len(relative_refs) > 0
+
+        # Verify all found items are $refs
+        for _, key, _ in relative_refs:
+            assert key == "$ref"
+
+        # Rewrite only $refs to be absolute HTTP URLs
+        opts = RewriteOptions(base_url=spec_url, refs_only=True)
+        changed = rewrite_urls_inplace(spec_doc, opts)
+        assert changed == len(relative_refs)
+
+        # Check that $ref was converted to absolute HTTP URL
+        schema_ref = spec_doc["paths"]["/users"]["get"]["responses"]["200"]["content"][
+            "application/json"
+        ]["schema"]["$ref"]
+        expected_ref = urljoin(spec_url, "schemas.json#/User")
+        assert schema_ref == expected_ref
+
+        # externalDocs.url should remain unchanged
+        assert spec_doc["externalDocs"]["url"] == "./docs.html"
+
+    def test_load_complex_document_from_http_refs_only(self, http_server):
+        """Test loading complex document from HTTP server with refs_only=True."""
+        spec_url = urljoin(http_server.base_url, "root-complex.json")
+        spec_text = load_uri(spec_url, 300, 300)
+
+        spec_doc = OpenAPIParser().parse(spec_text)
+
+        # Process only $refs
+        relative_refs = find_relative_urls(spec_doc, refs_only=True)
+        assert len(relative_refs) > 0
+
+        opts = RewriteOptions(base_url=spec_url, refs_only=True)
+        changed = rewrite_urls_inplace(spec_doc, opts)
+        assert changed == len(relative_refs)
+
+        # Root-relative server URL should NOT become absolute with refs_only=True
+        assert spec_doc["servers"][1]["url"] == "/api/v2"
+
+    def test_retarget_http_refs_only(self, http_server):
+        """Test retargeting only HTTP $refs, not other URL fields."""
+        spec_url = urljoin(http_server.base_url, "root-simple.json")
+        spec_text = load_uri(spec_url, 300, 300)
+
+        spec_doc = OpenAPIParser().parse(spec_text)
+
+        # Add some absolute URLs in both $ref and non-$ref fields
+        spec_doc["info"]["termsOfService"] = urljoin(http_server.base_url, "terms.html")
+        spec_doc["info"]["contact"] = {"url": urljoin(http_server.base_url, "contact.html")}
+
+        # First absolutize all $refs
+        opts1 = RewriteOptions(base_url=spec_url, refs_only=True)
+        rewrite_urls_inplace(spec_doc, opts1)
+
+        # Now add an absolute $ref
+        spec_doc["components"] = {
+            "schemas": {"Test": {"$ref": urljoin(http_server.base_url, "test-schema.json")}}
+        }
+
+        # Retarget only $refs from HTTP server to HTTPS production
+        opts2 = RewriteOptions(
+            base_url="https://api.production.com/v1/",
+            original_base_url=http_server.base_url + "/",
+            include_absolute_urls=True,
+            refs_only=True,
+        )
+        changed = rewrite_urls_inplace(spec_doc, opts2)
+
+        # Should have changed $refs only
+        assert changed > 0
+
+        # Check that non-$ref URL fields were NOT retargeted
+        assert spec_doc["info"]["termsOfService"] == urljoin(http_server.base_url, "terms.html")
+        assert spec_doc["info"]["contact"]["url"] == urljoin(http_server.base_url, "contact.html")
+
+        # Check that $ref was retargeted
+        assert (
+            spec_doc["components"]["schemas"]["Test"]["$ref"]
+            == "https://api.production.com/v1/test-schema.json"
+        )


### PR DESCRIPTION
* Add `refs_only` parameter to `count_references` and related utilities to allow selective counting of `$ref` fields exclusively.
* Update `iter_url_fields` and introduce `iter_ref_fields` to iterate over relevant fields based on `refs_only`.
* Extend test coverage to validate new functionality across various scenarios.