### PR TITLE
fix(validator): fix openapi_spec validator backend to provide proper codes

### DIFF
--- a/packages/jentic-openapi-validator/src/jentic/apitools/openapi/validator/backends/openapi_spec.py
+++ b/packages/jentic-openapi-validator/src/jentic/apitools/openapi/validator/backends/openapi_spec.py
@@ -57,8 +57,10 @@ class OpenAPISpecValidatorBackend(BaseValidatorBackend):
                 # objects that are truthy but stringify to '<unset>'. We must check the
                 # string representation to detect this.
                 code: str
-                validator_str = str(error.validator) if error.validator else ""
-                validator_value_str = str(error.validator_value) if error.validator_value else ""
+                validator_str = str(error.validator) if error.validator is not None else ""
+                validator_value_str = (
+                    str(error.validator_value) if error.validator_value is not None else ""
+                )
 
                 if validator_str and validator_str != "<unset>":
                     code = validator_str

--- a/packages/jentic-openapi-validator/tests/test_validate_openapi_spec.py
+++ b/packages/jentic-openapi-validator/tests/test_validate_openapi_spec.py
@@ -141,7 +141,7 @@ def test_duplicate_operation_id_code():
     # Find the duplicate operationId diagnostic
     duplicate_diag = None
     for diag in res.diagnostics:
-        if "operationId" in diag.message.lower() or "operation" in diag.message.lower():
+        if "operationid" in diag.message.lower() or "operation id" in diag.message.lower():
             duplicate_diag = diag
             break
 


### PR DESCRIPTION
 - Fix diagnostic code being <unset> in OpenAPISpecValidatorBackend when openapi-spec-validator returns sentinel objects
  - Add tests to prevent regression of <unset> diagnostic codes

  **Problem**

  The openapi-spec-validator library uses <unset> sentinel objects for error.validator and error.validator_value in certain validation errors (e.g., duplicate operationId). These sentinels are truthy but stringify to '<unset>', causing diagnostics like:

```json
  {
    "code": "<unset>",
    "message": "Operation ID 'getUserByName' for 'put' in '/user/{username}' is not unique"
  }
```

  **Solution**

  Updated the code determination logic in openapi_spec.py to:
  1. Convert values to strings first
  2. Check that the string is not empty and not '<unset>'
  3. Fall back to 'osv-validation-error' when no meaningful code can be determined

  Test plan

  - Added test_diagnostic_code_never_unset - ensures codes are never <unset>, None, or empty
  - Added test_duplicate_operation_id_code - specifically tests the duplicate operationId scenario
  - Added test_all_diagnostics_have_valid_codes - tests multiple validation error types have valid codes
  - All 60 validator tests pass
