### PR TITLE
feat(validator): add jentic-openapi-tools CLI with validate subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,19 +22,23 @@ architecture.
 
 ## Installation
 
-Install all packages at once using the meta-package:
+The recommended way to install is via the meta-package, which includes all packages and backends (parser, validator, transformer, plus the Spectral, Redocly, and SpecLynx backends):
 
 ```bash
 pip install jentic-openapi-tools
 ```
 
-Or install individual packages as needed:
+This also installs the `jentic-openapi-tools` CLI. If you only need specific functionality, you can install individual packages instead:
 
 ```bash
-pip install jentic-openapi-parser
-pip install jentic-openapi-validator
-pip install jentic-openapi-transformer
+pip install jentic-openapi-validator                  # Core validator with default + openapi-spec backends
+pip install jentic-openapi-validator-spectral          # Add Spectral backend
+pip install jentic-openapi-validator-redocly           # Add Redocly backend
+pip install jentic-openapi-parser                      # Parser only
+pip install jentic-openapi-transformer[redocly]        # Transformer with Redocly bundler
 ```
+
+Note that the CLI and Python API only have access to backends whose packages are installed. Installing the meta-package is the easiest way to get everything working, especially for CI pipelines and AI agents.
 
 **Prerequisites:**
 
@@ -102,11 +106,6 @@ jentic-openapi-tools validate https://petstore3.swagger.io/api/v3/openapi.json
 The CLI supports text, JSON, and GitHub Actions annotation output formats, stdin input, parallel multi-backend execution, and standard exit codes for CI integration. See the [jentic-openapi-validator README](https://github.com/jentic/jentic-openapi-tools/tree/HEAD/packages/jentic-openapi-validator) for the full CLI reference.
 
 ### Transforming OpenAPI Documents
-
-```bash
-# Install with Redocly backend support
-pip install jentic-openapi-transformer[redocly]
-```
 
 ```python
 from jentic.apitools.openapi.transformer.bundler.core import OpenAPIBundler

--- a/README.md
+++ b/README.md
@@ -84,6 +84,23 @@ else:
         print(f"Error: {diagnostic.message}")
 ```
 
+### Command-Line Interface
+
+The `jentic-openapi-validator` package includes the `jentic-openapi-tools` CLI for validating OpenAPI documents directly from the terminal:
+
+```bash
+# Validate a local file
+jentic-openapi-tools validate openapi.yaml
+
+# Use a specific backend and get JSON output
+jentic-openapi-tools validate -b spectral -f json openapi.yaml
+
+# Validate a remote URL
+jentic-openapi-tools validate https://petstore3.swagger.io/api/v3/openapi.json
+```
+
+The CLI supports text, JSON, and GitHub Actions annotation output formats, stdin input, parallel multi-backend execution, and standard exit codes for CI integration. See the [jentic-openapi-validator README](https://github.com/jentic/jentic-openapi-tools/tree/HEAD/packages/jentic-openapi-validator) for the full CLI reference.
+
 ### Transforming OpenAPI Documents
 
 ```bash

--- a/packages/jentic-openapi-validator/README.md
+++ b/packages/jentic-openapi-validator/README.md
@@ -34,7 +34,73 @@ For validation with Redocly:
 pip install jentic-openapi-validator-redocly
 ```
 
-## Quick Start
+## Command-Line Interface
+
+The package includes the `jentic-openapi-tools` CLI with a `validate` subcommand for validating OpenAPI documents directly from the terminal.
+
+### Basic Usage
+
+```bash
+# Validate a local file
+jentic-openapi-tools validate openapi.yaml
+
+# Validate a remote URL
+jentic-openapi-tools validate https://petstore3.swagger.io/api/v3/openapi.json
+
+# Validate from stdin
+cat openapi.yaml | jentic-openapi-tools validate -
+
+# Use a specific backend
+jentic-openapi-tools validate -b spectral openapi.yaml
+
+# Use multiple backends
+jentic-openapi-tools validate -b spectral -b redocly openapi.yaml
+
+# Use all installed backends
+jentic-openapi-tools validate -a openapi.yaml
+```
+
+### Output Formats
+
+The CLI supports three output formats selected with `-f`/`--format`:
+
+```bash
+# Human-readable text (default)
+jentic-openapi-tools validate openapi.yaml
+
+# Machine-readable JSON with LSP diagnostics
+jentic-openapi-tools validate -f json openapi.yaml
+
+# GitHub Actions workflow annotations
+jentic-openapi-tools validate -f github openapi.yaml
+```
+
+The text format outputs one line per diagnostic with severity, position, message, rule code, and source backend. JSON output includes full LSP diagnostic objects and a summary with counts by severity. GitHub format emits `::error`, `::warning`, and `::notice` annotations that render inline in pull request diffs.
+
+### Exit Codes
+
+The CLI uses three exit codes: 0 when the document is valid, 1 when validation errors are found, and 2 for usage or runtime errors (missing file, unknown backend, etc.). This makes it straightforward to use in CI pipelines and shell scripts.
+
+### Additional Options
+
+```bash
+# Run backends in parallel
+jentic-openapi-tools validate --parallel -b spectral -b redocly openapi.yaml
+
+# Suppress output, only set exit code
+jentic-openapi-tools validate --quiet openapi.yaml
+
+# Disable colored output (also respects NO_COLOR env var)
+jentic-openapi-tools validate --no-color openapi.yaml
+
+# List available backends
+jentic-openapi-tools validate --list-backends
+
+# Show version
+jentic-openapi-tools --version
+```
+
+## Python API
 
 ### Basic Validation
 

--- a/packages/jentic-openapi-validator/README.md
+++ b/packages/jentic-openapi-validator/README.md
@@ -88,6 +88,12 @@ The CLI uses three exit codes: 0 when the document is valid, 1 when validation e
 ### Additional Options
 
 ```bash
+# Write output to a file instead of stdout
+jentic-openapi-tools validate -o results.json -f json openapi.yaml
+
+# Write to file only, suppress stdout
+jentic-openapi-tools validate -q -o results.txt openapi.yaml
+
 # Run backends in parallel
 jentic-openapi-tools validate --parallel -b spectral -b redocly openapi.yaml
 

--- a/packages/jentic-openapi-validator/README.md
+++ b/packages/jentic-openapi-validator/README.md
@@ -13,26 +13,30 @@ A Python library for validating OpenAPI documents using pluggable validator back
 
 ## Installation
 
+The easiest way to install the validator with all available backends is via the `jentic-openapi-tools` meta-package:
+
+```bash
+pip install jentic-openapi-tools
+```
+
+This installs the full toolkit including the Spectral, Redocly, and SpecLynx validator backends, the CLI, and all other packages. If you only need the validator, you can install it individually:
+
 ```bash
 pip install jentic-openapi-validator
 ```
 
+The core package ships with two built-in backends (`default` and `openapi-spec`). Additional backends are available as separate packages and are automatically discovered when installed:
+
+```bash
+pip install jentic-openapi-validator-spectral    # Spectral CLI backend
+pip install jentic-openapi-validator-redocly     # Redocly CLI backend
+```
+
+The CLI (`jentic-openapi-tools validate --list-backends`) shows which backends are currently available.
+
 **Prerequisites:**
 - Python 3.11+
-
-**Optional Backends:**
-
-For advanced validation with Spectral:
-
-```bash
-pip install jentic-openapi-validator-spectral
-```
-
-For validation with Redocly:
-
-```bash
-pip install jentic-openapi-validator-redocly
-```
+- Node.js >=20.19.0 and npm (required for Spectral and Redocly backends)
 
 ## Command-Line Interface
 

--- a/packages/jentic-openapi-validator/pyproject.toml
+++ b/packages/jentic-openapi-validator/pyproject.toml
@@ -17,6 +17,9 @@ dependencies = [
 spectral = ["jentic-openapi-validator-spectral~=1.0.0-alpha.49"]
 redocly = ["jentic-openapi-validator-redocly~=1.0.0-alpha.49"]
 
+[project.scripts]
+openapi-validate = "jentic.apitools.openapi.validator.cli:main"
+
 [project.urls]
 Homepage = "https://github.com/jentic/jentic-openapi-tools"
 

--- a/packages/jentic-openapi-validator/pyproject.toml
+++ b/packages/jentic-openapi-validator/pyproject.toml
@@ -18,7 +18,7 @@ spectral = ["jentic-openapi-validator-spectral~=1.0.0-alpha.49"]
 redocly = ["jentic-openapi-validator-redocly~=1.0.0-alpha.49"]
 
 [project.scripts]
-openapi-validate = "jentic.apitools.openapi.validator.cli:main"
+jentic-openapi-tools = "jentic.apitools.openapi.validator.cli:main"
 
 [project.urls]
 Homepage = "https://github.com/jentic/jentic-openapi-tools"

--- a/packages/jentic-openapi-validator/src/jentic/apitools/openapi/validator/cli.py
+++ b/packages/jentic-openapi-validator/src/jentic/apitools/openapi/validator/cli.py
@@ -1,0 +1,308 @@
+"""Command-line interface for jentic-openapi-validator."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.metadata
+import json
+import os
+import sys
+from pathlib import Path
+
+from lsprotocol import converters as lsp_converters
+from lsprotocol.types import DiagnosticSeverity
+
+from jentic.apitools.openapi.common.uri import is_http_https_url
+from jentic.apitools.openapi.validator.core import OpenAPIValidator
+from jentic.apitools.openapi.validator.core.diagnostics import JenticDiagnostic, ValidationResult
+
+
+_SEVERITY_LABELS: dict[DiagnosticSeverity, str] = {
+    DiagnosticSeverity.Error: "error",
+    DiagnosticSeverity.Warning: "warning",
+    DiagnosticSeverity.Information: "info",
+    DiagnosticSeverity.Hint: "hint",
+}
+
+_GITHUB_LEVELS: dict[DiagnosticSeverity, str] = {
+    DiagnosticSeverity.Error: "error",
+    DiagnosticSeverity.Warning: "warning",
+    DiagnosticSeverity.Information: "notice",
+    DiagnosticSeverity.Hint: "notice",
+}
+
+# ANSI color codes
+_COLORS: dict[DiagnosticSeverity, str] = {
+    DiagnosticSeverity.Error: "\033[31m",  # red
+    DiagnosticSeverity.Warning: "\033[33m",  # yellow
+    DiagnosticSeverity.Information: "\033[34m",  # blue
+    DiagnosticSeverity.Hint: "\033[2m",  # dim
+}
+_RESET = "\033[0m"
+
+
+def _get_version() -> str:
+    return importlib.metadata.version("jentic-openapi-validator")
+
+
+def _use_color(args: argparse.Namespace) -> bool:
+    if args.no_color:
+        return False
+    if os.environ.get("NO_COLOR") is not None:
+        return False
+    return sys.stdout.isatty()
+
+
+def _resolve_backends(raw: list[str] | None) -> list[str]:
+    """Expand comma-separated backend names into a flat list."""
+    if raw is None:
+        return ["default"]
+    backends: list[str] = []
+    for item in raw:
+        backends.extend(name.strip() for name in item.split(",") if name.strip())
+    return backends or ["default"]
+
+
+def _count_by_severity(diagnostics: list[JenticDiagnostic]) -> dict[str, int]:
+    counts = {"errors": 0, "warnings": 0, "information": 0, "hints": 0}
+    for d in diagnostics:
+        if d.severity == DiagnosticSeverity.Error:
+            counts["errors"] += 1
+        elif d.severity == DiagnosticSeverity.Warning:
+            counts["warnings"] += 1
+        elif d.severity == DiagnosticSeverity.Information:
+            counts["information"] += 1
+        elif d.severity == DiagnosticSeverity.Hint:
+            counts["hints"] += 1
+    return counts
+
+
+def _summary_line(document_label: str, counts: dict[str, int], total: int) -> str:
+    if total == 0:
+        return f"{document_label}: no problems found"
+    parts: list[str] = []
+    if counts["errors"]:
+        parts.append(f"{counts['errors']} error{'s' if counts['errors'] != 1 else ''}")
+    if counts["warnings"]:
+        parts.append(f"{counts['warnings']} warning{'s' if counts['warnings'] != 1 else ''}")
+    if counts["information"]:
+        parts.append(f"{counts['information']} info")
+    if counts["hints"]:
+        parts.append(f"{counts['hints']} hint{'s' if counts['hints'] != 1 else ''}")
+    detail = ", ".join(parts)
+    return f"{document_label}: {total} problem{'s' if total != 1 else ''} ({detail})"
+
+
+def format_text(result: ValidationResult, document_label: str, *, color: bool = False) -> str:
+    counts = _count_by_severity(result.diagnostics)
+    total = len(result.diagnostics)
+    lines: list[str] = [_summary_line(document_label, counts, total)]
+
+    if total > 0:
+        lines.append("")
+
+    for d in result.diagnostics:
+        severity = d.severity or DiagnosticSeverity.Error
+        label = _SEVERITY_LABELS.get(severity, "error")
+        line = d.range.start.line + 1 if d.range else 1
+        col = d.range.start.character + 1 if d.range else 1
+        pos = f"{line}:{col}"
+        code = d.code or ""
+        source = f"({d.source})" if d.source else ""
+
+        if color:
+            severity_color = _COLORS.get(severity, "")
+            lines.append(
+                f"  {severity_color}{label:7s}{_RESET}  {pos:>6s}  {d.message}  {code}  {source}"
+            )
+        else:
+            lines.append(f"  {label:7s}  {pos:>6s}  {d.message}  {code}  {source}")
+
+    return "\n".join(lines)
+
+
+def format_json(result: ValidationResult) -> str:
+    converter = lsp_converters.get_converter()
+    counts = _count_by_severity(result.diagnostics)
+    output = {
+        "valid": result.valid,
+        "diagnostics": [converter.unstructure(d) for d in result.diagnostics],
+        "summary": {**counts, "total": len(result.diagnostics)},
+    }
+    return json.dumps(output, indent=2)
+
+
+def format_github(result: ValidationResult, document_label: str) -> str:
+    lines: list[str] = []
+    for d in result.diagnostics:
+        severity = d.severity or DiagnosticSeverity.Error
+        level = _GITHUB_LEVELS.get(severity, "notice")
+        line = d.range.start.line + 1 if d.range else 1
+        col = d.range.start.character + 1 if d.range else 1
+        code_suffix = f" ({d.code})" if d.code else ""
+        lines.append(
+            f"::{level} file={document_label},line={line},col={col}::{d.message}{code_suffix}"
+        )
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="openapi-validate",
+        description="Validate OpenAPI documents using pluggable backends.",
+    )
+    parser.add_argument(
+        "document",
+        nargs="?",
+        help="Path or URI to an OpenAPI document, or '-' to read from stdin.",
+    )
+    parser.add_argument(
+        "-b",
+        "--backend",
+        action="append",
+        default=None,
+        metavar="NAME",
+        help="Backend to use (repeatable, or comma-separated). Default: 'default'.",
+    )
+    parser.add_argument(
+        "-a",
+        "--all-backends",
+        action="store_true",
+        help="Use all available validator backends.",
+    )
+    parser.add_argument(
+        "--list-backends",
+        action="store_true",
+        help="List available validator backends and exit.",
+    )
+    parser.add_argument(
+        "--base-url",
+        default=None,
+        help="Base URL for resolving relative $ref references.",
+    )
+    parser.add_argument(
+        "--target",
+        default=None,
+        help="Target identifier for validation context.",
+    )
+    parser.add_argument(
+        "--parallel",
+        action="store_true",
+        help="Run backends in parallel.",
+    )
+    parser.add_argument(
+        "--max-workers",
+        type=int,
+        default=None,
+        help="Thread pool size for I/O backends (requires --parallel).",
+    )
+    parser.add_argument(
+        "--max-process-workers",
+        type=int,
+        default=None,
+        help="Process pool size for CPU-heavy backends (requires --parallel).",
+    )
+    parser.add_argument(
+        "-f",
+        "--format",
+        choices=["text", "json", "github"],
+        default="text",
+        help="Output format (default: text).",
+    )
+    parser.add_argument(
+        "-q",
+        "--quiet",
+        action="store_true",
+        help="Suppress output; only set exit code.",
+    )
+    parser.add_argument(
+        "--no-color",
+        action="store_true",
+        help="Disable colored output.",
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {_get_version()}",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point. Returns exit code: 0=valid, 1=invalid, 2=error."""
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    # --list-backends: print available backends and exit
+    if args.list_backends:
+        for name in sorted(OpenAPIValidator.list_backends()):
+            print(name)
+        return 0
+
+    # Check mutual exclusivity before document requirement
+    if args.all_backends and args.backend:
+        parser.error("--all-backends/-a and --backend/-b are mutually exclusive")
+
+    # Require document when not using --list-backends
+    if args.document is None:
+        parser.error("the following arguments are required: document")
+
+    # Resolve document input
+    document_label = args.document
+    if args.document == "-":
+        document: str | dict = sys.stdin.read()
+        document_label = "<stdin>"
+    elif is_http_https_url(args.document):
+        document = args.document
+    else:
+        path = Path(args.document)
+        if not path.exists():
+            print(f"error: file not found: {args.document}", file=sys.stderr)
+            return 2
+        document = path.resolve().as_uri()
+
+    # Resolve backends
+    if args.all_backends:
+        backends = OpenAPIValidator.list_backends()
+    else:
+        backends = _resolve_backends(args.backend)
+
+    # Create validator
+    try:
+        validator = OpenAPIValidator(backends=backends)
+    except ValueError as exc:
+        available = ", ".join(sorted(OpenAPIValidator.list_backends()))
+        print(f"error: {exc}\navailable backends: {available}", file=sys.stderr)
+        return 2
+
+    # Run validation
+    try:
+        result = validator.validate(
+            document,
+            base_url=args.base_url,
+            target=args.target,
+            parallel=args.parallel,
+            max_workers=args.max_workers,
+            max_process_workers=args.max_process_workers,
+        )
+    except Exception as exc:
+        print(f"error: validation failed: {exc}", file=sys.stderr)
+        return 2
+
+    # Output
+    if not args.quiet:
+        if args.format == "json":
+            print(format_json(result))
+        elif args.format == "github":
+            output = format_github(result, document_label)
+            if output:
+                print(output)
+        else:
+            color = _use_color(args)
+            print(format_text(result, document_label, color=color))
+
+    return 0 if result.valid else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/jentic-openapi-validator/src/jentic/apitools/openapi/validator/cli.py
+++ b/packages/jentic-openapi-validator/src/jentic/apitools/openapi/validator/cli.py
@@ -146,17 +146,23 @@ def format_github(result: ValidationResult, document_label: str) -> str:
     return "\n".join(lines)
 
 
-def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
-        prog="openapi-validate",
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+
+def _build_validate_subparser(subparsers: argparse._SubParsersAction) -> None:
+    validate = subparsers.add_parser(
+        "validate",
+        help="Validate an OpenAPI document.",
         description="Validate OpenAPI documents using pluggable backends.",
     )
-    parser.add_argument(
+    validate.add_argument(
         "document",
         nargs="?",
         help="Path or URI to an OpenAPI document, or '-' to read from stdin.",
     )
-    parser.add_argument(
+    validate.add_argument(
         "-b",
         "--backend",
         action="append",
@@ -164,75 +170,87 @@ def build_parser() -> argparse.ArgumentParser:
         metavar="NAME",
         help="Backend to use (repeatable, or comma-separated). Default: 'default'.",
     )
-    parser.add_argument(
+    validate.add_argument(
         "-a",
         "--all-backends",
         action="store_true",
         help="Use all available validator backends.",
     )
-    parser.add_argument(
+    validate.add_argument(
         "--list-backends",
         action="store_true",
         help="List available validator backends and exit.",
     )
-    parser.add_argument(
+    validate.add_argument(
         "--base-url",
         default=None,
         help="Base URL for resolving relative $ref references.",
     )
-    parser.add_argument(
+    validate.add_argument(
         "--target",
         default=None,
         help="Target identifier for validation context.",
     )
-    parser.add_argument(
+    validate.add_argument(
         "--parallel",
         action="store_true",
         help="Run backends in parallel.",
     )
-    parser.add_argument(
+    validate.add_argument(
         "--max-workers",
         type=int,
         default=None,
         help="Thread pool size for I/O backends (requires --parallel).",
     )
-    parser.add_argument(
+    validate.add_argument(
         "--max-process-workers",
         type=int,
         default=None,
         help="Process pool size for CPU-heavy backends (requires --parallel).",
     )
-    parser.add_argument(
+    validate.add_argument(
         "-f",
         "--format",
         choices=["text", "json", "github"],
         default="text",
         help="Output format (default: text).",
     )
-    parser.add_argument(
+    validate.add_argument(
         "-q",
         "--quiet",
         action="store_true",
         help="Suppress output; only set exit code.",
     )
-    parser.add_argument(
+    validate.add_argument(
         "--no-color",
         action="store_true",
         help="Disable colored output.",
+    )
+    validate.set_defaults(func=_run_validate)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="jentic-openapi-tools",
+        description="Jentic OpenAPI tooling CLI.",
     )
     parser.add_argument(
         "--version",
         action="version",
         version=f"%(prog)s {_get_version()}",
     )
+    subparsers = parser.add_subparsers(dest="command")
+    _build_validate_subparser(subparsers)
     return parser
 
 
-def main(argv: list[str] | None = None) -> int:
-    """CLI entry point. Returns exit code: 0=valid, 1=invalid, 2=error."""
-    parser = build_parser()
-    args = parser.parse_args(argv)
+# ---------------------------------------------------------------------------
+# Subcommand handlers
+# ---------------------------------------------------------------------------
 
+
+def _run_validate(args: argparse.Namespace) -> int:
+    """Run the validate subcommand. Returns exit code: 0=valid, 1=invalid, 2=error."""
     # --list-backends: print available backends and exit
     if args.list_backends:
         for name in sorted(OpenAPIValidator.list_backends()):
@@ -241,11 +259,16 @@ def main(argv: list[str] | None = None) -> int:
 
     # Check mutual exclusivity before document requirement
     if args.all_backends and args.backend:
-        parser.error("--all-backends/-a and --backend/-b are mutually exclusive")
+        print(
+            "error: --all-backends/-a and --backend/-b are mutually exclusive",
+            file=sys.stderr,
+        )
+        return 2
 
     # Require document when not using --list-backends
     if args.document is None:
-        parser.error("the following arguments are required: document")
+        print("error: the following arguments are required: document", file=sys.stderr)
+        return 2
 
     # Resolve document input
     document_label = args.document
@@ -302,6 +325,23 @@ def main(argv: list[str] | None = None) -> int:
             print(format_text(result, document_label, color=color))
 
     return 0 if result.valid else 1
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point. Returns exit code: 0=success, 1=invalid, 2=error."""
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if not args.command:
+        parser.print_help()
+        return 2
+
+    return args.func(args)
 
 
 if __name__ == "__main__":

--- a/packages/jentic-openapi-validator/src/jentic/apitools/openapi/validator/cli.py
+++ b/packages/jentic-openapi-validator/src/jentic/apitools/openapi/validator/cli.py
@@ -235,10 +235,17 @@ def _build_validate_subparser(subparsers: argparse._SubParsersAction) -> None:
         help="Output format (default: text).",
     )
     validate.add_argument(
+        "-o",
+        "--output",
+        default=None,
+        metavar="FILE",
+        help="Write validation output to FILE instead of stdout.",
+    )
+    validate.add_argument(
         "-q",
         "--quiet",
         action="store_true",
-        help="Suppress output; only set exit code.",
+        help="Suppress stdout output; only set exit code. Can be combined with -o to write only to file.",
     )
     validate.add_argument(
         "--no-color",
@@ -334,17 +341,26 @@ def _run_validate(args: argparse.Namespace) -> int:
         print(f"error: validation failed: {exc}", file=sys.stderr)
         return 2
 
-    # Output
-    if not args.quiet:
-        if args.format == "json":
-            print(format_json(result))
-        elif args.format == "github":
-            output = format_github(result, document_label)
-            if output:
-                print(output)
-        else:
-            color = _use_color(args)
-            print(format_text(result, document_label, color=color))
+    # Format output
+    if args.format == "json":
+        formatted = format_json(result)
+    elif args.format == "github":
+        formatted = format_github(result, document_label)
+    else:
+        color = not args.output and _use_color(args)
+        formatted = format_text(result, document_label, color=color)
+
+    # Write to file
+    if args.output:
+        try:
+            Path(args.output).write_text(formatted + "\n", encoding="utf-8")
+        except OSError as exc:
+            print(f"error: cannot write to {args.output}: {exc}", file=sys.stderr)
+            return 2
+
+    # Write to stdout
+    if not args.quiet and formatted:
+        print(formatted)
 
     return 0 if result.valid else 1
 

--- a/packages/jentic-openapi-validator/src/jentic/apitools/openapi/validator/cli.py
+++ b/packages/jentic-openapi-validator/src/jentic/apitools/openapi/validator/cli.py
@@ -42,7 +42,10 @@ _RESET = "\033[0m"
 
 
 def _get_version() -> str:
-    return importlib.metadata.version("jentic-openapi-validator")
+    try:
+        return importlib.metadata.version("jentic-openapi-validator")
+    except importlib.metadata.PackageNotFoundError:
+        return "unknown"
 
 
 def _use_color(args: argparse.Namespace) -> bool:
@@ -132,17 +135,33 @@ def format_json(result: ValidationResult) -> str:
     return json.dumps(output, indent=2)
 
 
+def _escape_github_message(value: str) -> str:
+    """Escape special characters in GitHub Actions workflow command messages."""
+    return value.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+
+
+def _escape_github_property(value: str) -> str:
+    """Escape special characters in GitHub Actions workflow command property values."""
+    return (
+        value.replace("%", "%25")
+        .replace("\r", "%0D")
+        .replace("\n", "%0A")
+        .replace(":", "%3A")
+        .replace(",", "%2C")
+    )
+
+
 def format_github(result: ValidationResult, document_label: str) -> str:
     lines: list[str] = []
+    escaped_label = _escape_github_property(document_label)
     for d in result.diagnostics:
         severity = d.severity or DiagnosticSeverity.Error
         level = _GITHUB_LEVELS.get(severity, "notice")
         line = d.range.start.line + 1 if d.range else 1
         col = d.range.start.character + 1 if d.range else 1
         code_suffix = f" ({d.code})" if d.code else ""
-        lines.append(
-            f"::{level} file={document_label},line={line},col={col}::{d.message}{code_suffix}"
-        )
+        message = _escape_github_message(f"{d.message}{code_suffix}")
+        lines.append(f"::{level} file={escaped_label},line={line},col={col}::{message}")
     return "\n".join(lines)
 
 
@@ -200,13 +219,13 @@ def _build_validate_subparser(subparsers: argparse._SubParsersAction) -> None:
         "--max-workers",
         type=int,
         default=None,
-        help="Thread pool size for I/O backends (requires --parallel).",
+        help="Thread pool size for I/O backends (ignored unless --parallel is used).",
     )
     validate.add_argument(
         "--max-process-workers",
         type=int,
         default=None,
-        help="Process pool size for CPU-heavy backends (requires --parallel).",
+        help="Process pool size for CPU-heavy backends (ignored unless --parallel is used).",
     )
     validate.add_argument(
         "-f",
@@ -281,6 +300,9 @@ def _run_validate(args: argparse.Namespace) -> int:
         path = Path(args.document)
         if not path.exists():
             print(f"error: file not found: {args.document}", file=sys.stderr)
+            return 2
+        if not path.is_file():
+            print(f"error: not a file: {args.document}", file=sys.stderr)
             return 2
         document = path.resolve().as_uri()
 

--- a/packages/jentic-openapi-validator/tests/test_cli.py
+++ b/packages/jentic-openapi-validator/tests/test_cli.py
@@ -11,7 +11,7 @@ from unittest.mock import patch
 import pytest
 from lsprotocol.types import DiagnosticSeverity, Position, Range
 
-from jentic.apitools.openapi.validator.cli import build_parser, format_text, main
+from jentic.apitools.openapi.validator.cli import build_parser, format_github, format_text, main
 from jentic.apitools.openapi.validator.core.diagnostics import JenticDiagnostic, ValidationResult
 
 
@@ -198,6 +198,12 @@ class TestValidation:
         err = capsys.readouterr().err
         assert "document" in err
 
+    def test_directory_exits_two(self, tmp_path, capsys):
+        exit_code = main(["validate", str(tmp_path)])
+        assert exit_code == 2
+        err = capsys.readouterr().err
+        assert "not a file" in err
+
 
 # ---------------------------------------------------------------------------
 # Output formats
@@ -301,6 +307,36 @@ class TestFormatText:
         result = ValidationResult(diagnostics=[diag])
         output = format_text(result, "spec.yaml")
         assert "1:1" in output
+
+
+# ---------------------------------------------------------------------------
+# GitHub format escaping
+# ---------------------------------------------------------------------------
+
+
+class TestFormatGithub:
+    def test_escapes_special_chars_in_message(self):
+        diag = JenticDiagnostic(
+            range=Range(start=Position(line=0, character=0), end=Position(line=0, character=1)),
+            message="line1\nline2",
+            severity=DiagnosticSeverity.Error,
+            source="test",
+        )
+        result = ValidationResult(diagnostics=[diag])
+        output = format_github(result, "spec.yaml")
+        assert "%0A" in output
+        assert "\n" not in output.split("::")[2]
+
+    def test_escapes_special_chars_in_file_label(self):
+        diag = JenticDiagnostic(
+            range=Range(start=Position(line=0, character=0), end=Position(line=0, character=1)),
+            message="test",
+            severity=DiagnosticSeverity.Warning,
+            source="test",
+        )
+        result = ValidationResult(diagnostics=[diag])
+        output = format_github(result, "path:with,special")
+        assert "path%3Awith%2Cspecial" in output
 
 
 # ---------------------------------------------------------------------------

--- a/packages/jentic-openapi-validator/tests/test_cli.py
+++ b/packages/jentic-openapi-validator/tests/test_cli.py
@@ -1,0 +1,334 @@
+"""Tests for the openapi-validate CLI."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from io import StringIO
+from unittest.mock import patch
+
+import pytest
+from lsprotocol.types import DiagnosticSeverity, Position, Range
+
+from jentic.apitools.openapi.validator.cli import build_parser, format_text, main
+from jentic.apitools.openapi.validator.core.diagnostics import JenticDiagnostic, ValidationResult
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+VALID_SPEC = {
+    "openapi": "3.1.0",
+    "info": {"title": "Test API", "version": "1.0.0"},
+    "paths": {},
+    "servers": [{"url": "https://api.example.com"}],
+}
+
+INVALID_SPEC = {
+    "openapi": "3.1.0",
+    "info": {"title": "Test API", "version": "1.0.0"},
+    # missing paths and servers -> triggers errors
+}
+
+
+@pytest.fixture()
+def valid_spec_file(tmp_path):
+    spec = tmp_path / "valid.json"
+    spec.write_text(json.dumps(VALID_SPEC))
+    return spec
+
+
+@pytest.fixture()
+def invalid_spec_file(tmp_path):
+    spec = tmp_path / "invalid.json"
+    spec.write_text(json.dumps(INVALID_SPEC))
+    return spec
+
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+
+class TestBuildParser:
+    def test_document_positional(self):
+        args = build_parser().parse_args(["spec.yaml"])
+        assert args.document == "spec.yaml"
+
+    def test_backend_single(self):
+        args = build_parser().parse_args(["-b", "spectral", "spec.yaml"])
+        assert args.backend == ["spectral"]
+
+    def test_backend_multiple(self):
+        args = build_parser().parse_args(["-b", "spectral", "-b", "redocly", "spec.yaml"])
+        assert args.backend == ["spectral", "redocly"]
+
+    def test_format_choices(self):
+        for fmt in ("text", "json", "github"):
+            args = build_parser().parse_args(["--format", fmt, "spec.yaml"])
+            assert args.format == fmt
+
+    def test_parallel_flag(self):
+        args = build_parser().parse_args(["--parallel", "spec.yaml"])
+        assert args.parallel is True
+
+    def test_all_backends_flag(self):
+        args = build_parser().parse_args(["-a", "spec.yaml"])
+        assert args.all_backends is True
+
+    def test_all_backends_long_flag(self):
+        args = build_parser().parse_args(["--all-backends", "spec.yaml"])
+        assert args.all_backends is True
+
+    def test_defaults(self):
+        args = build_parser().parse_args(["spec.yaml"])
+        assert args.backend is None
+        assert args.all_backends is False
+        assert args.format == "text"
+        assert args.parallel is False
+        assert args.quiet is False
+        assert args.no_color is False
+        assert args.base_url is None
+        assert args.target is None
+        assert args.max_workers is None
+        assert args.max_process_workers is None
+
+    def test_base_url(self):
+        args = build_parser().parse_args(["--base-url", "https://example.com", "spec.yaml"])
+        assert args.base_url == "https://example.com"
+
+    def test_target(self):
+        args = build_parser().parse_args(["--target", "my-target", "spec.yaml"])
+        assert args.target == "my-target"
+
+
+# ---------------------------------------------------------------------------
+# --list-backends
+# ---------------------------------------------------------------------------
+
+
+class TestListBackends:
+    def test_prints_and_exits_zero(self, capsys):
+        exit_code = main(["--list-backends"])
+        assert exit_code == 0
+        output = capsys.readouterr().out
+        assert "default" in output
+        assert "openapi-spec" in output
+
+    def test_works_without_document(self, capsys):
+        exit_code = main(["--list-backends"])
+        assert exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# Validation outcomes
+# ---------------------------------------------------------------------------
+
+
+class TestValidation:
+    def test_valid_document_exits_zero(self, valid_spec_file, capsys):
+        exit_code = main(["--no-color", str(valid_spec_file)])
+        assert exit_code == 0
+        output = capsys.readouterr().out
+        assert "no problems found" in output
+
+    def test_invalid_document_exits_one(self, invalid_spec_file, capsys):
+        exit_code = main(["--no-color", str(invalid_spec_file)])
+        assert exit_code == 1
+        output = capsys.readouterr().out
+        assert "error" in output.lower()
+
+    def test_file_not_found_exits_two(self, capsys):
+        exit_code = main(["/nonexistent/path/spec.yaml"])
+        assert exit_code == 2
+        err = capsys.readouterr().err
+        assert "file not found" in err
+
+    def test_invalid_backend_exits_two(self, valid_spec_file, capsys):
+        exit_code = main(["-b", "nonexistent-backend", str(valid_spec_file)])
+        assert exit_code == 2
+        err = capsys.readouterr().err
+        assert "nonexistent-backend" in err
+        assert "available backends" in err
+
+    def test_comma_separated_backends(self, valid_spec_file, capsys):
+        exit_code = main(["-b", "default,openapi-spec", str(valid_spec_file)])
+        assert exit_code == 0
+
+    def test_specific_backend(self, valid_spec_file, capsys):
+        exit_code = main(["-b", "openapi-spec", str(valid_spec_file)])
+        assert exit_code == 0
+
+    def test_all_backends(self, valid_spec_file, capsys):
+        exit_code = main(["-a", "--no-color", str(valid_spec_file)])
+        assert exit_code == 0
+
+    def test_all_backends_mutually_exclusive_with_backend(self, valid_spec_file):
+        with pytest.raises(SystemExit, match="2"):
+            main(["-a", "-b", "default", str(valid_spec_file)])
+
+
+# ---------------------------------------------------------------------------
+# Output formats
+# ---------------------------------------------------------------------------
+
+
+class TestOutputFormats:
+    def test_json_format_valid(self, valid_spec_file, capsys):
+        main(["--format", "json", str(valid_spec_file)])
+        output = json.loads(capsys.readouterr().out)
+        assert output["valid"] is True
+        assert isinstance(output["diagnostics"], list)
+        assert "summary" in output
+        assert "total" in output["summary"]
+
+    def test_json_format_invalid(self, invalid_spec_file, capsys):
+        main(["--format", "json", str(invalid_spec_file)])
+        output = json.loads(capsys.readouterr().out)
+        assert output["valid"] is False
+        assert output["summary"]["errors"] > 0
+
+    def test_github_format(self, invalid_spec_file, capsys):
+        main(["--format", "github", str(invalid_spec_file)])
+        output = capsys.readouterr().out
+        for line in output.strip().splitlines():
+            assert line.startswith("::")
+
+    def test_github_format_valid_no_output(self, valid_spec_file, capsys):
+        main(["--format", "github", str(valid_spec_file)])
+        output = capsys.readouterr().out
+        assert output == ""
+
+    def test_quiet_suppresses_output(self, invalid_spec_file, capsys):
+        exit_code = main(["--quiet", str(invalid_spec_file)])
+        assert exit_code == 1
+        captured = capsys.readouterr()
+        assert captured.out == ""
+
+    def test_text_format_shows_diagnostics(self, invalid_spec_file, capsys):
+        main(["--no-color", str(invalid_spec_file)])
+        output = capsys.readouterr().out
+        assert "problem" in output
+
+
+# ---------------------------------------------------------------------------
+# Stdin support
+# ---------------------------------------------------------------------------
+
+
+class TestStdin:
+    def test_stdin_valid_document(self, capsys):
+        with patch("sys.stdin", StringIO(json.dumps(VALID_SPEC))):
+            exit_code = main(["--no-color", "-"])
+        assert exit_code == 0
+        output = capsys.readouterr().out
+        assert "<stdin>" in output
+
+    def test_stdin_invalid_document(self, capsys):
+        with patch("sys.stdin", StringIO(json.dumps(INVALID_SPEC))):
+            exit_code = main(["--no-color", "-"])
+        assert exit_code == 1
+
+
+# ---------------------------------------------------------------------------
+# Entry point integration
+# ---------------------------------------------------------------------------
+
+
+class TestFormatText:
+    def test_positions_are_one_indexed(self):
+        diag = JenticDiagnostic(
+            range=Range(start=Position(line=0, character=0), end=Position(line=0, character=5)),
+            message="test issue",
+            severity=DiagnosticSeverity.Error,
+            source="test",
+        )
+        result = ValidationResult(diagnostics=[diag])
+        output = format_text(result, "spec.yaml")
+        # LSP line 0, char 0 should render as 1:1 in user-facing text
+        assert "1:1" in output
+
+    def test_positions_offset(self):
+        diag = JenticDiagnostic(
+            range=Range(start=Position(line=9, character=4), end=Position(line=9, character=10)),
+            message="test issue",
+            severity=DiagnosticSeverity.Warning,
+            source="test",
+        )
+        result = ValidationResult(diagnostics=[diag])
+        output = format_text(result, "spec.yaml")
+        # LSP line 9, char 4 should render as 10:5
+        assert "10:5" in output
+
+    def test_missing_range_defaults_to_1_1(self):
+        diag = JenticDiagnostic(
+            range=None,
+            message="test issue",
+            severity=DiagnosticSeverity.Error,
+            source="test",
+        )
+        result = ValidationResult(diagnostics=[diag])
+        output = format_text(result, "spec.yaml")
+        assert "1:1" in output
+
+
+# ---------------------------------------------------------------------------
+# HTTP/HTTPS URL support
+# ---------------------------------------------------------------------------
+
+
+class TestHttpUrl:
+    def test_http_url_passed_to_validator(self, capsys):
+        url = "https://example.com/openapi.json"
+        mock_result = ValidationResult(diagnostics=[])
+        with patch("jentic.apitools.openapi.validator.cli.OpenAPIValidator") as mock_cls:
+            mock_cls.return_value.validate.return_value = mock_result
+            exit_code = main(["--no-color", url])
+
+        assert exit_code == 0
+        mock_cls.return_value.validate.assert_called_once()
+        call_args = mock_cls.return_value.validate.call_args
+        assert call_args[0][0] == url
+
+    def test_http_url_not_treated_as_file(self, capsys):
+        url = "http://example.com/spec.yaml"
+        mock_result = ValidationResult(diagnostics=[])
+        with patch("jentic.apitools.openapi.validator.cli.OpenAPIValidator") as mock_cls:
+            mock_cls.return_value.validate.return_value = mock_result
+            exit_code = main(["--no-color", url])
+
+        # Should not fail with "file not found"
+        assert exit_code == 0
+        err = capsys.readouterr().err
+        assert "file not found" not in err
+
+
+# ---------------------------------------------------------------------------
+# Argument validation ordering
+# ---------------------------------------------------------------------------
+
+
+class TestArgumentOrdering:
+    def test_mutual_exclusivity_before_document_check(self):
+        """--all-backends + --backend should error even without a document."""
+        with pytest.raises(SystemExit, match="2"):
+            main(["-a", "-b", "default"])
+
+
+# ---------------------------------------------------------------------------
+# Entry point integration
+# ---------------------------------------------------------------------------
+
+
+class TestEntryPoint:
+    def test_module_invocation(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "jentic.apitools.openapi.validator.cli", "--list-backends"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == 0
+        assert "default" in result.stdout

--- a/packages/jentic-openapi-validator/tests/test_cli.py
+++ b/packages/jentic-openapi-validator/tests/test_cli.py
@@ -1,4 +1,4 @@
-"""Tests for the openapi-validate CLI."""
+"""Tests for the jentic-openapi-tools CLI."""
 
 from __future__ import annotations
 
@@ -48,42 +48,61 @@ def invalid_spec_file(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# Top-level parser
+# ---------------------------------------------------------------------------
+
+
+class TestTopLevel:
+    def test_no_subcommand_prints_help_and_exits_two(self, capsys):
+        exit_code = main([])
+        assert exit_code == 2
+        output = capsys.readouterr().out
+        assert "validate" in output
+
+    def test_version_flag(self):
+        with pytest.raises(SystemExit, match="0"):
+            main(["--version"])
+
+
+# ---------------------------------------------------------------------------
 # Argument parsing
 # ---------------------------------------------------------------------------
 
 
 class TestBuildParser:
     def test_document_positional(self):
-        args = build_parser().parse_args(["spec.yaml"])
+        args = build_parser().parse_args(["validate", "spec.yaml"])
         assert args.document == "spec.yaml"
 
     def test_backend_single(self):
-        args = build_parser().parse_args(["-b", "spectral", "spec.yaml"])
+        args = build_parser().parse_args(["validate", "-b", "spectral", "spec.yaml"])
         assert args.backend == ["spectral"]
 
     def test_backend_multiple(self):
-        args = build_parser().parse_args(["-b", "spectral", "-b", "redocly", "spec.yaml"])
+        args = build_parser().parse_args(
+            ["validate", "-b", "spectral", "-b", "redocly", "spec.yaml"]
+        )
         assert args.backend == ["spectral", "redocly"]
 
     def test_format_choices(self):
         for fmt in ("text", "json", "github"):
-            args = build_parser().parse_args(["--format", fmt, "spec.yaml"])
+            args = build_parser().parse_args(["validate", "--format", fmt, "spec.yaml"])
             assert args.format == fmt
 
     def test_parallel_flag(self):
-        args = build_parser().parse_args(["--parallel", "spec.yaml"])
+        args = build_parser().parse_args(["validate", "--parallel", "spec.yaml"])
         assert args.parallel is True
 
     def test_all_backends_flag(self):
-        args = build_parser().parse_args(["-a", "spec.yaml"])
+        args = build_parser().parse_args(["validate", "-a", "spec.yaml"])
         assert args.all_backends is True
 
     def test_all_backends_long_flag(self):
-        args = build_parser().parse_args(["--all-backends", "spec.yaml"])
+        args = build_parser().parse_args(["validate", "--all-backends", "spec.yaml"])
         assert args.all_backends is True
 
     def test_defaults(self):
-        args = build_parser().parse_args(["spec.yaml"])
+        args = build_parser().parse_args(["validate", "spec.yaml"])
         assert args.backend is None
         assert args.all_backends is False
         assert args.format == "text"
@@ -96,11 +115,13 @@ class TestBuildParser:
         assert args.max_process_workers is None
 
     def test_base_url(self):
-        args = build_parser().parse_args(["--base-url", "https://example.com", "spec.yaml"])
+        args = build_parser().parse_args(
+            ["validate", "--base-url", "https://example.com", "spec.yaml"]
+        )
         assert args.base_url == "https://example.com"
 
     def test_target(self):
-        args = build_parser().parse_args(["--target", "my-target", "spec.yaml"])
+        args = build_parser().parse_args(["validate", "--target", "my-target", "spec.yaml"])
         assert args.target == "my-target"
 
 
@@ -111,14 +132,14 @@ class TestBuildParser:
 
 class TestListBackends:
     def test_prints_and_exits_zero(self, capsys):
-        exit_code = main(["--list-backends"])
+        exit_code = main(["validate", "--list-backends"])
         assert exit_code == 0
         output = capsys.readouterr().out
         assert "default" in output
         assert "openapi-spec" in output
 
     def test_works_without_document(self, capsys):
-        exit_code = main(["--list-backends"])
+        exit_code = main(["validate", "--list-backends"])
         assert exit_code == 0
 
 
@@ -129,45 +150,53 @@ class TestListBackends:
 
 class TestValidation:
     def test_valid_document_exits_zero(self, valid_spec_file, capsys):
-        exit_code = main(["--no-color", str(valid_spec_file)])
+        exit_code = main(["validate", "--no-color", str(valid_spec_file)])
         assert exit_code == 0
         output = capsys.readouterr().out
         assert "no problems found" in output
 
     def test_invalid_document_exits_one(self, invalid_spec_file, capsys):
-        exit_code = main(["--no-color", str(invalid_spec_file)])
+        exit_code = main(["validate", "--no-color", str(invalid_spec_file)])
         assert exit_code == 1
         output = capsys.readouterr().out
         assert "error" in output.lower()
 
     def test_file_not_found_exits_two(self, capsys):
-        exit_code = main(["/nonexistent/path/spec.yaml"])
+        exit_code = main(["validate", "/nonexistent/path/spec.yaml"])
         assert exit_code == 2
         err = capsys.readouterr().err
         assert "file not found" in err
 
     def test_invalid_backend_exits_two(self, valid_spec_file, capsys):
-        exit_code = main(["-b", "nonexistent-backend", str(valid_spec_file)])
+        exit_code = main(["validate", "-b", "nonexistent-backend", str(valid_spec_file)])
         assert exit_code == 2
         err = capsys.readouterr().err
         assert "nonexistent-backend" in err
         assert "available backends" in err
 
     def test_comma_separated_backends(self, valid_spec_file, capsys):
-        exit_code = main(["-b", "default,openapi-spec", str(valid_spec_file)])
+        exit_code = main(["validate", "-b", "default,openapi-spec", str(valid_spec_file)])
         assert exit_code == 0
 
     def test_specific_backend(self, valid_spec_file, capsys):
-        exit_code = main(["-b", "openapi-spec", str(valid_spec_file)])
+        exit_code = main(["validate", "-b", "openapi-spec", str(valid_spec_file)])
         assert exit_code == 0
 
     def test_all_backends(self, valid_spec_file, capsys):
-        exit_code = main(["-a", "--no-color", str(valid_spec_file)])
+        exit_code = main(["validate", "-a", "--no-color", str(valid_spec_file)])
         assert exit_code == 0
 
-    def test_all_backends_mutually_exclusive_with_backend(self, valid_spec_file):
-        with pytest.raises(SystemExit, match="2"):
-            main(["-a", "-b", "default", str(valid_spec_file)])
+    def test_all_backends_mutually_exclusive_with_backend(self, valid_spec_file, capsys):
+        exit_code = main(["validate", "-a", "-b", "default", str(valid_spec_file)])
+        assert exit_code == 2
+        err = capsys.readouterr().err
+        assert "mutually exclusive" in err
+
+    def test_missing_document_exits_two(self, capsys):
+        exit_code = main(["validate"])
+        assert exit_code == 2
+        err = capsys.readouterr().err
+        assert "document" in err
 
 
 # ---------------------------------------------------------------------------
@@ -177,7 +206,7 @@ class TestValidation:
 
 class TestOutputFormats:
     def test_json_format_valid(self, valid_spec_file, capsys):
-        main(["--format", "json", str(valid_spec_file)])
+        main(["validate", "--format", "json", str(valid_spec_file)])
         output = json.loads(capsys.readouterr().out)
         assert output["valid"] is True
         assert isinstance(output["diagnostics"], list)
@@ -185,30 +214,30 @@ class TestOutputFormats:
         assert "total" in output["summary"]
 
     def test_json_format_invalid(self, invalid_spec_file, capsys):
-        main(["--format", "json", str(invalid_spec_file)])
+        main(["validate", "--format", "json", str(invalid_spec_file)])
         output = json.loads(capsys.readouterr().out)
         assert output["valid"] is False
         assert output["summary"]["errors"] > 0
 
     def test_github_format(self, invalid_spec_file, capsys):
-        main(["--format", "github", str(invalid_spec_file)])
+        main(["validate", "--format", "github", str(invalid_spec_file)])
         output = capsys.readouterr().out
         for line in output.strip().splitlines():
             assert line.startswith("::")
 
     def test_github_format_valid_no_output(self, valid_spec_file, capsys):
-        main(["--format", "github", str(valid_spec_file)])
+        main(["validate", "--format", "github", str(valid_spec_file)])
         output = capsys.readouterr().out
         assert output == ""
 
     def test_quiet_suppresses_output(self, invalid_spec_file, capsys):
-        exit_code = main(["--quiet", str(invalid_spec_file)])
+        exit_code = main(["validate", "--quiet", str(invalid_spec_file)])
         assert exit_code == 1
         captured = capsys.readouterr()
         assert captured.out == ""
 
     def test_text_format_shows_diagnostics(self, invalid_spec_file, capsys):
-        main(["--no-color", str(invalid_spec_file)])
+        main(["validate", "--no-color", str(invalid_spec_file)])
         output = capsys.readouterr().out
         assert "problem" in output
 
@@ -221,19 +250,19 @@ class TestOutputFormats:
 class TestStdin:
     def test_stdin_valid_document(self, capsys):
         with patch("sys.stdin", StringIO(json.dumps(VALID_SPEC))):
-            exit_code = main(["--no-color", "-"])
+            exit_code = main(["validate", "--no-color", "-"])
         assert exit_code == 0
         output = capsys.readouterr().out
         assert "<stdin>" in output
 
     def test_stdin_invalid_document(self, capsys):
         with patch("sys.stdin", StringIO(json.dumps(INVALID_SPEC))):
-            exit_code = main(["--no-color", "-"])
+            exit_code = main(["validate", "--no-color", "-"])
         assert exit_code == 1
 
 
 # ---------------------------------------------------------------------------
-# Entry point integration
+# Text format positions
 # ---------------------------------------------------------------------------
 
 
@@ -285,7 +314,7 @@ class TestHttpUrl:
         mock_result = ValidationResult(diagnostics=[])
         with patch("jentic.apitools.openapi.validator.cli.OpenAPIValidator") as mock_cls:
             mock_cls.return_value.validate.return_value = mock_result
-            exit_code = main(["--no-color", url])
+            exit_code = main(["validate", "--no-color", url])
 
         assert exit_code == 0
         mock_cls.return_value.validate.assert_called_once()
@@ -297,7 +326,7 @@ class TestHttpUrl:
         mock_result = ValidationResult(diagnostics=[])
         with patch("jentic.apitools.openapi.validator.cli.OpenAPIValidator") as mock_cls:
             mock_cls.return_value.validate.return_value = mock_result
-            exit_code = main(["--no-color", url])
+            exit_code = main(["validate", "--no-color", url])
 
         # Should not fail with "file not found"
         assert exit_code == 0
@@ -311,10 +340,12 @@ class TestHttpUrl:
 
 
 class TestArgumentOrdering:
-    def test_mutual_exclusivity_before_document_check(self):
+    def test_mutual_exclusivity_before_document_check(self, capsys):
         """--all-backends + --backend should error even without a document."""
-        with pytest.raises(SystemExit, match="2"):
-            main(["-a", "-b", "default"])
+        exit_code = main(["validate", "-a", "-b", "default"])
+        assert exit_code == 2
+        err = capsys.readouterr().err
+        assert "mutually exclusive" in err
 
 
 # ---------------------------------------------------------------------------
@@ -325,7 +356,13 @@ class TestArgumentOrdering:
 class TestEntryPoint:
     def test_module_invocation(self):
         result = subprocess.run(
-            [sys.executable, "-m", "jentic.apitools.openapi.validator.cli", "--list-backends"],
+            [
+                sys.executable,
+                "-m",
+                "jentic.apitools.openapi.validator.cli",
+                "validate",
+                "--list-backends",
+            ],
             capture_output=True,
             text=True,
             timeout=30,

--- a/packages/jentic-openapi-validator/tests/test_cli.py
+++ b/packages/jentic-openapi-validator/tests/test_cli.py
@@ -249,6 +249,50 @@ class TestOutputFormats:
 
 
 # ---------------------------------------------------------------------------
+# File output (-o/--output)
+# ---------------------------------------------------------------------------
+
+
+class TestFileOutput:
+    def test_writes_to_file(self, valid_spec_file, tmp_path, capsys):
+        out_file = tmp_path / "result.txt"
+        exit_code = main(["validate", "--no-color", "-o", str(out_file), str(valid_spec_file)])
+        assert exit_code == 0
+        content = out_file.read_text(encoding="utf-8")
+        assert "no problems found" in content
+
+    def test_also_prints_to_stdout(self, valid_spec_file, tmp_path, capsys):
+        out_file = tmp_path / "result.txt"
+        main(["validate", "--no-color", "-o", str(out_file), str(valid_spec_file)])
+        stdout = capsys.readouterr().out
+        assert "no problems found" in stdout
+
+    def test_quiet_suppresses_stdout_but_writes_file(self, valid_spec_file, tmp_path, capsys):
+        out_file = tmp_path / "result.txt"
+        exit_code = main(
+            ["validate", "--no-color", "-q", "-o", str(out_file), str(valid_spec_file)]
+        )
+        assert exit_code == 0
+        assert capsys.readouterr().out == ""
+        content = out_file.read_text(encoding="utf-8")
+        assert "no problems found" in content
+
+    def test_json_format_to_file(self, valid_spec_file, tmp_path, capsys):
+        out_file = tmp_path / "result.json"
+        main(["validate", "-f", "json", "-o", str(out_file), str(valid_spec_file)])
+        content = json.loads(out_file.read_text(encoding="utf-8"))
+        assert content["valid"] is True
+
+    def test_unwritable_path_exits_two(self, valid_spec_file, capsys):
+        exit_code = main(
+            ["validate", "--no-color", "-o", "/nonexistent/dir/out.txt", str(valid_spec_file)]
+        )
+        assert exit_code == 2
+        err = capsys.readouterr().err
+        assert "cannot write to" in err
+
+
+# ---------------------------------------------------------------------------
 # Stdin support
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                                                                                     
  Adds a `jentic-openapi-tools validate` CLI for validating OpenAPI documents from the terminal, with support for multiple output formats, pluggable backends, and CI integration.                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                                                                                     
  The CLI is registered as a console script entry point in the validator package and uses argparse subcommands, so future packages (e.g. transformer) can add their own subcommands (e.g. `bundle`) under the same `jentic-openapi-tools` binary.                                                                                                                                    
                  
  ### What's included                                                                                                                                                                                                                                                                                                                                                                
                  
  - `validate` subcommand with text, JSON, and GitHub Actions annotation output formats                                                                                                                                                                                                                                                                                              
  - Pluggable backend selection (`-b spectral`, `-b redocly`, `-a` for all, `--list-backends`)
  - Stdin (`-`) and HTTP/HTTPS URL input alongside local file paths                                                                                                                                                                                                                                                                                                                  
  - Parallel multi-backend execution (`--parallel`)                                                                                                                                                                                                                                                                                                                                  
  - Quiet mode and `NO_COLOR` support                                                                                                                                                                                                                                                                                                                                                
  - Exit codes: 0 = valid, 1 = errors found, 2 = usage/runtime error                                                                                                                                                                                                                                                                                                                 
  - 38 tests covering argument parsing, all output formats, stdin, URL passthrough, and subprocess entry point                                                                                                                                                                                                                                                                       
  - CLI documentation in the validator package README and a brief reference in the root README 