### PR TITLE
fix(deps): add speclynx to sync-versions and fix stale dependency pin

### DIFF
--- a/.github/scripts/sync-versions.py
+++ b/.github/scripts/sync-versions.py
@@ -57,6 +57,7 @@ def sync_versions(root_dir: Path, new_version: str) -> None:
         "jentic-openapi-validator",
         "jentic-openapi-validator-redocly",
         "jentic-openapi-validator-spectral",
+        "jentic-openapi-validator-speclynx",
     ]
 
     # Update root pyproject.toml (both version and dependencies)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
   "jentic-openapi-validator~=1.0.0-alpha.50",
   "jentic-openapi-validator-redocly~=1.0.0-alpha.50",
   "jentic-openapi-validator-spectral~=1.0.0-alpha.50",
-  "jentic-openapi-validator-speclynx~=1.0.0-alpha.33"
+  "jentic-openapi-validator-speclynx~=1.0.0-alpha.50"
 ]
 
 [project.urls]


### PR DESCRIPTION
The speclynx package was missing from the jentic_packages list in sync-versions.py, causing its version pin in the root pyproject.toml to go stale during releases. This led to pipx install failures due to incompatible version constraints.