### PR TITLE
fix(build): switch root meta-package to uv_build for pip compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,13 +72,13 @@ jentic-openapi-validator-redocly = { workspace = true }
 jentic-openapi-validator-spectral = { workspace = true }
 jentic-openapi-validator-speclynx = { workspace = true }
 
-[build-system]
-requires = ["setuptools>=75.8,<82.1"]
-build-backend = "setuptools.build_meta"
+[tool.uv.build-backend]
+namespace = true
+module-name = "jentic_openapi_tools"
 
-[tool.setuptools]
-packages = []
-license-files = ["LICENSE", "NOTICE"]
+[build-system]
+requires = ["uv_build~=0.8.15"]
+build-backend = "uv_build"
 
 [tool.ruff]
 target-version = "py311"


### PR DESCRIPTION
setuptools passes dependency specifiers like ~=1.0.0-alpha.51 verbatim into wheel metadata, but pip cannot parse this non-canonical PEP 440 form. uv_build normalizes specifiers automatically (e.g. ~=1.0.0a51), which pip resolves correctly. This fixes pipx/pip install failures.