### PR TITLE
fix(build): add console script entry point to root meta-package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,9 @@ dependencies = [
   "jentic-openapi-validator-speclynx~=1.0.0-alpha.52"
 ]
 
+[project.scripts]
+jentic-openapi-tools = "jentic.apitools.openapi.validator.cli:main"
+
 [project.urls]
 Homepage = "https://github.com/jentic/jentic-openapi-tools"
 


### PR DESCRIPTION
pipx requires the installed package itself to declare console scripts. The jentic-openapi-tools CLI was only declared in the validator sub-package, causing pipx to report "No apps associated with package".