### PR TITLE
fix(deps): update @redocly/cli to v2.28.0, @stoplight/spectral-cli to v6.15.1, @speclynx/apidom to v4.7.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -223,6 +223,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -479,9 +480,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@redocly/ajv": {
-      "version": "8.17.4",
-      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.17.4.tgz",
-      "integrity": "sha512-BieiCML/IgP6x99HZByJSt7fJE4ipgzO7KAFss92Bs+PEI35BhY7vGIysFXLT+YmS7nHtQjZjhOQyPPEf7xGHA==",
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.18.3.tgz",
+      "integrity": "sha512-l42u0of3hY98sN2A+M4qTX1O/KrpgGH32Hu9kP2GtHyD5Dfqq86PKFLe5dwaD8DEnNmlOlll2BAmeEtf0DaySg==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -495,28 +496,29 @@
       }
     },
     "node_modules/@redocly/cli": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-2.20.0.tgz",
-      "integrity": "sha512-8R+NzB2RnT0PacozLRfdKymqWb6YtD1IbrW74e9Q63lhRcLUHYJWtHNoxT98C0k0R/7gViKhBJIygUecybIn0A==",
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-2.28.0.tgz",
+      "integrity": "sha512-hAHtMjo4fLdLqZXtZwQqlwGnAiOzEAh7EPbE01rs9j7cewj2btOXrGQW8v6Eg3gDh+i77/DOxxazRWvZ/zAa7w==",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/exporter-trace-otlp-http": "0.202.0",
         "@opentelemetry/resources": "2.0.1",
         "@opentelemetry/sdk-trace-node": "2.0.1",
         "@opentelemetry/semantic-conventions": "1.34.0",
-        "@redocly/openapi-core": "2.20.0",
-        "@redocly/respect-core": "2.20.0",
+        "@redocly/cli-otel": "0.1.2",
+        "@redocly/openapi-core": "2.28.0",
+        "@redocly/respect-core": "2.28.0",
         "abort-controller": "^3.0.0",
-        "ajv": "npm:@redocly/ajv@8.17.4",
+        "ajv": "npm:@redocly/ajv@8.18.0",
         "ajv-formats": "^3.0.1",
         "colorette": "^1.2.0",
         "cookie": "^0.7.2",
         "dotenv": "16.4.7",
         "glob": "^13.0.5",
-        "handlebars": "^4.7.6",
+        "handlebars": "^4.7.9",
         "https-proxy-agent": "^7.0.5",
         "mobx": "^6.0.4",
-        "picomatch": "^4.0.3",
+        "picomatch": "^4.0.4",
         "pluralize": "^8.0.0",
         "react": "^17.0.0 || ^18.2.0 || ^19.2.1",
         "react-dom": "^17.0.0 || ^18.2.0 || ^19.2.1",
@@ -526,7 +528,7 @@
         "simple-websocket": "^9.0.0",
         "styled-components": "6.3.9",
         "ulid": "^3.0.1",
-        "undici": "^6.23.0",
+        "undici": "6.24.0",
         "yargs": "17.0.1"
       },
       "bin": {
@@ -538,46 +540,47 @@
         "npm": ">=10"
       }
     },
-    "node_modules/@redocly/cli/node_modules/ajv": {
-      "name": "@redocly/ajv",
-      "version": "8.17.4",
-      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.17.4.tgz",
-      "integrity": "sha512-BieiCML/IgP6x99HZByJSt7fJE4ipgzO7KAFss92Bs+PEI35BhY7vGIysFXLT+YmS7nHtQjZjhOQyPPEf7xGHA==",
+    "node_modules/@redocly/cli-otel": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@redocly/cli-otel/-/cli-otel-0.1.2.tgz",
+      "integrity": "sha512-Bg7BoO5t1x3lVK+KhA5aGPmeXpQmdf6WtTYHhelKJCsQ+tRMiJoFAQoKHoBHAoNxXrhlS3K9lKFLHGmtxsFQfA==",
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
+        "ulid": "^2.3.0"
+      }
+    },
+    "node_modules/@redocly/cli-otel/node_modules/ulid": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ulid/-/ulid-2.4.0.tgz",
+      "integrity": "sha512-fIRiVTJNcSRmXKPZtGzFQv9WRrZ3M9eoptl/teFJvjOzmpU+/K/JH6HZ8deBfb5vMEpicJcLn7JmvdknlMq7Zg==",
+      "license": "MIT",
+      "bin": {
+        "ulid": "bin/cli.js"
       }
     },
     "node_modules/@redocly/config": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.43.0.tgz",
-      "integrity": "sha512-AbyFKRHKJ2VBmh9nO2lrG9tO2Gu/Lmnfdj4Uwoh7h/a7jWr1104t4fBgQZs/NwgGBAOkGmyQYAvardwyBeRGZA==",
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.48.0.tgz",
+      "integrity": "sha512-8W3wz+Q7y4e9klJWlYOvQWK5r7P2Mo589vcjtlT5coOxsyAdt53k8Vb8iAqnRiGWExbjBQmSbL2XbuU747Nf6Q==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "2.7.2"
       }
     },
     "node_modules/@redocly/openapi-core": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-2.20.0.tgz",
-      "integrity": "sha512-cyMqjFt0jKp0FDYX5MYGbg+jdUXVvrtSMadRaviaoq1o4JmuejIaK7+fnhJhBZD389ui6ihJp2//nI2MIgQWMw==",
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-2.28.0.tgz",
+      "integrity": "sha512-Htpp4PsjKMgEuMT9iJu4iuFFzWCDe8FylvpGaQEA5D7jZXWv+8XvnqhpGCKN2cM/n/Uri2QfqNdw0JlKIC59sg==",
       "license": "MIT",
       "dependencies": {
-        "@redocly/ajv": "^8.17.4",
-        "@redocly/config": "^0.43.0",
-        "ajv": "npm:@redocly/ajv@8.17.4",
+        "@redocly/ajv": "^8.18.0",
+        "@redocly/config": "^0.48.0",
+        "ajv": "npm:@redocly/ajv@8.18.0",
         "ajv-formats": "^3.0.1",
         "colorette": "^1.2.0",
         "js-levenshtein": "^1.1.6",
         "js-yaml": "^4.1.0",
-        "picomatch": "^4.0.3",
+        "picomatch": "^4.0.4",
         "pluralize": "^8.0.0",
         "yaml-ast-parser": "0.0.43"
       },
@@ -586,62 +589,28 @@
         "npm": ">=10"
       }
     },
-    "node_modules/@redocly/openapi-core/node_modules/ajv": {
-      "name": "@redocly/ajv",
-      "version": "8.17.4",
-      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.17.4.tgz",
-      "integrity": "sha512-BieiCML/IgP6x99HZByJSt7fJE4ipgzO7KAFss92Bs+PEI35BhY7vGIysFXLT+YmS7nHtQjZjhOQyPPEf7xGHA==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
     "node_modules/@redocly/respect-core": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/@redocly/respect-core/-/respect-core-2.20.0.tgz",
-      "integrity": "sha512-bslonUVnd2hPr1UbZnBCghB7gaoddBcYq6pSIL025N0xQT5s93ZU6zufJtJzm2c2RNWUBHyL6pfmZrrlb2nm+A==",
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/@redocly/respect-core/-/respect-core-2.28.0.tgz",
+      "integrity": "sha512-svjCRzXsj/EyN7chfB9pTVYvWT1+hlOqMkZVlkrH6PqFKXAHYeP47YRW9+3omUSDBd1Ph4A4J4NBUW1PRph5+g==",
       "license": "MIT",
       "dependencies": {
         "@faker-js/faker": "^7.6.0",
         "@noble/hashes": "^1.8.0",
-        "@redocly/ajv": "8.17.4",
-        "@redocly/openapi-core": "2.20.0",
-        "ajv": "npm:@redocly/ajv@8.17.4",
+        "@redocly/ajv": "^8.18.0",
+        "@redocly/openapi-core": "2.28.0",
+        "ajv": "npm:@redocly/ajv@8.18.0",
         "better-ajv-errors": "^1.2.0",
         "colorette": "^2.0.20",
         "json-pointer": "^0.6.2",
         "jsonpath-rfc9535": "1.3.0",
-        "openapi-sampler": "^1.7.0",
+        "openapi-sampler": "^1.7.1",
         "outdent": "^0.8.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=22.12.0 || >=20.19.0 <21.0.0",
         "npm": ">=10"
-      }
-    },
-    "node_modules/@redocly/respect-core/node_modules/ajv": {
-      "name": "@redocly/ajv",
-      "version": "8.17.4",
-      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.17.4.tgz",
-      "integrity": "sha512-BieiCML/IgP6x99HZByJSt7fJE4ipgzO7KAFss92Bs+PEI35BhY7vGIysFXLT+YmS7nHtQjZjhOQyPPEf7xGHA==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/@redocly/respect-core/node_modules/colorette": {
@@ -750,15 +719,15 @@
       }
     },
     "node_modules/@speclynx/apidom-core": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-core/-/apidom-core-4.0.5.tgz",
-      "integrity": "sha512-mBQ1gxiRL13VcXaOA0b2ZfZf5v4nE4M14tWzK+TWEWiWAyBVRD66zVGa+TfmGMP/vCnomhmV8JS3iYM+ouJJlA==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-core/-/apidom-core-4.7.1.tgz",
+      "integrity": "sha512-4RSaIqSiuo+lWkY2FIBdsI5WbcZi2UQRDQ6B8xFDf6QpKq3aVIySlIkkykWpBOK0RQUHFAkaKKvz3LHPp/CE4Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-datamodel": "4.0.5",
-        "@speclynx/apidom-error": "4.0.5",
-        "@speclynx/apidom-traverse": "4.0.5",
+        "@speclynx/apidom-datamodel": "4.7.1",
+        "@speclynx/apidom-error": "4.7.1",
+        "@speclynx/apidom-traverse": "4.7.1",
         "ramda": "~0.32.0",
         "ramda-adjunct": "^6.0.0",
         "short-unique-id": "^5.3.2",
@@ -767,446 +736,496 @@
       }
     },
     "node_modules/@speclynx/apidom-datamodel": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-datamodel/-/apidom-datamodel-4.0.5.tgz",
-      "integrity": "sha512-+C7wsckuXnvj3e10cSuuL6IVLBCsPP7wArn+u2s4AT8RA9QCq4plkcIx5bIIdfRLw5O/FoPEb/85zvz49zZyUQ==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-datamodel/-/apidom-datamodel-4.7.1.tgz",
+      "integrity": "sha512-cUFbPJ5cU52lrRuiu+sZqYXUF9dBXyFsX84fCpulsm4m1PeIHQvdBtpKlcLRwooLpQyplD0BA0lA7DT7c22M4A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-error": "4.0.5",
+        "@speclynx/apidom-error": "4.7.1",
         "ramda": "~0.32.0"
       }
     },
     "node_modules/@speclynx/apidom-error": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-error/-/apidom-error-4.0.5.tgz",
-      "integrity": "sha512-25vIehxFvRW4MlQF0stuvCYSmt3QqknGSiE9126/jxumV10Zh/exuI/PkdY4itXfzJCROeLOmDydjuFIt3HlOg==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-error/-/apidom-error-4.7.1.tgz",
+      "integrity": "sha512-1wQixrgm3jKyuFR8AVF6fcTyttzhgeXwvMYVURWXpnugZSG8aB+YuGCav5ikiyuTFXPYU8Cswth31/1UH4r+9Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.28.4"
       }
     },
     "node_modules/@speclynx/apidom-json-path": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-json-path/-/apidom-json-path-4.0.5.tgz",
-      "integrity": "sha512-+Ux8qljvC08f2x6ERU4DVoTQo9sCJIGeawBDWfwTlzqi2Ws7ru4NQWF9+jjVecbjXBAzkIJHZnVcp7NNFaMBWQ==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-json-path/-/apidom-json-path-4.7.1.tgz",
+      "integrity": "sha512-s2wR3nIiGMuUGXHipXrwlmpyLJQeQpxU4wN12J55wr6GemSIOw4DL67tz4YJjFCIPctoY/nDkiqhcSgdWnwonA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-datamodel": "4.0.5",
-        "@speclynx/apidom-error": "4.0.5",
-        "@swaggerexpert/jsonpath": "^4.0.3"
+        "@speclynx/apidom-datamodel": "4.7.1",
+        "@speclynx/apidom-error": "4.7.1",
+        "@swaggerexpert/jsonpath": "^4.0.4"
       }
     },
     "node_modules/@speclynx/apidom-json-pointer": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-json-pointer/-/apidom-json-pointer-4.0.5.tgz",
-      "integrity": "sha512-1ndMkpEQXPon+BJ4vcOphx6i8okTGs34fbtrxWvc/gRE5iVD1ECEKUNHNuSpe9IeNC4CRHMTGeU6hL+Glb8FMw==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-json-pointer/-/apidom-json-pointer-4.7.1.tgz",
+      "integrity": "sha512-1JM0IPGI9L08/kHUUloYJpz1EmhltzQ//Tl6XW5di3hHAVB2O3oFrUftWf8Q8blpCqFxR9rufWuiY4GSAvZ5Xw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-datamodel": "4.0.5",
-        "@speclynx/apidom-error": "4.0.5",
+        "@speclynx/apidom-datamodel": "4.7.1",
+        "@speclynx/apidom-error": "4.7.1",
         "@swaggerexpert/json-pointer": "^3.0.1"
       }
     },
     "node_modules/@speclynx/apidom-ns-arazzo-1": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-arazzo-1/-/apidom-ns-arazzo-1-4.0.5.tgz",
-      "integrity": "sha512-a00lLlebBSon3+yd86vxXQTZMHd7LxudN1UXR9tIMbrDIcO+TbfzuYdMnOlCdBA1ss1k83G4uCWWtUFKyIWdWg==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-arazzo-1/-/apidom-ns-arazzo-1-4.7.1.tgz",
+      "integrity": "sha512-qeiCCtj26grVo6K0nw0D+L5GwESMrZaLLd39jqUAzOwBgzHcZsyiS2eUHzsKd5f/7GHhOTMcp046wRVaQRGpVQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.0.5",
-        "@speclynx/apidom-datamodel": "4.0.5",
-        "@speclynx/apidom-ns-json-schema-2020-12": "4.0.5",
-        "@speclynx/apidom-traverse": "4.0.5",
+        "@speclynx/apidom-core": "4.7.1",
+        "@speclynx/apidom-datamodel": "4.7.1",
+        "@speclynx/apidom-ns-json-schema-2020-12": "4.7.1",
+        "@speclynx/apidom-traverse": "4.7.1",
         "ramda": "~0.32.0",
         "ramda-adjunct": "^6.0.0",
         "ts-mixer": "^6.0.4"
       }
     },
     "node_modules/@speclynx/apidom-ns-asyncapi-2": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-asyncapi-2/-/apidom-ns-asyncapi-2-4.0.5.tgz",
-      "integrity": "sha512-QzLE28gOxmtA2ubvREgpnnk4CZltzWeft3Ji5it3CjMkXUUJRNbY4wX0C+x6CroFjNZoJv7mp6fDwEVWybnx+Q==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-asyncapi-2/-/apidom-ns-asyncapi-2-4.7.1.tgz",
+      "integrity": "sha512-siH2OdGbHQlZJ0hq5CDiNdQYosslzl2ZLoZlj0yAXckUfWxOHiVc4xh1GMkkYW0T2/IV4JKm8a1n0ldEprkOgQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.0.5",
-        "@speclynx/apidom-datamodel": "4.0.5",
-        "@speclynx/apidom-ns-json-schema-draft-7": "4.0.5",
-        "@speclynx/apidom-traverse": "4.0.5",
+        "@speclynx/apidom-core": "4.7.1",
+        "@speclynx/apidom-datamodel": "4.7.1",
+        "@speclynx/apidom-ns-json-schema-draft-7": "4.7.1",
+        "@speclynx/apidom-traverse": "4.7.1",
         "ramda": "~0.32.0",
         "ramda-adjunct": "^6.0.0",
         "ts-mixer": "^6.0.4"
       }
     },
     "node_modules/@speclynx/apidom-ns-json-schema-2019-09": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-json-schema-2019-09/-/apidom-ns-json-schema-2019-09-4.0.5.tgz",
-      "integrity": "sha512-Ntb3DZRtctZsaU/Idl8FKvxJtWR7x6WIEiZe9zlH7TsWvwDLpoY/aSB41TxNjE2Gm3H9uSnlYHyLcu6oOUf6iw==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-json-schema-2019-09/-/apidom-ns-json-schema-2019-09-4.7.1.tgz",
+      "integrity": "sha512-4Ioo5GMzImJVuvepRnP7K3gkJNIgXCqe+taZdrpzpqSRuxnaAbuAUBMNpCXVg3sqczhxMrHYI2QiOALgDFDt9A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.0.5",
-        "@speclynx/apidom-datamodel": "4.0.5",
-        "@speclynx/apidom-error": "4.0.5",
-        "@speclynx/apidom-ns-json-schema-draft-6": "4.0.5",
-        "@speclynx/apidom-ns-json-schema-draft-7": "4.0.5",
-        "@speclynx/apidom-traverse": "4.0.5",
+        "@speclynx/apidom-core": "4.7.1",
+        "@speclynx/apidom-datamodel": "4.7.1",
+        "@speclynx/apidom-error": "4.7.1",
+        "@speclynx/apidom-ns-json-schema-draft-6": "4.7.1",
+        "@speclynx/apidom-ns-json-schema-draft-7": "4.7.1",
+        "@speclynx/apidom-traverse": "4.7.1",
         "ramda": "~0.32.0",
         "ramda-adjunct": "^6.0.0",
         "ts-mixer": "^6.0.4"
       }
     },
     "node_modules/@speclynx/apidom-ns-json-schema-2020-12": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-json-schema-2020-12/-/apidom-ns-json-schema-2020-12-4.0.5.tgz",
-      "integrity": "sha512-gDk3Ffl5nHsxfN+q+uXP1paUFP7OiAr2MzC5bD0hlifl0SlIylx6Yzlfx6D3ceL047svFyede65w+tM7vRvxeA==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-json-schema-2020-12/-/apidom-ns-json-schema-2020-12-4.7.1.tgz",
+      "integrity": "sha512-N1G4dXhCJXBGln6AV129vjxYKxMVZAMfgnmJlQdKpGmpoFGSgikO2j0E2+0Dp7qbpXnxYT4Md65AHrXKE9SIdA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.0.5",
-        "@speclynx/apidom-datamodel": "4.0.5",
-        "@speclynx/apidom-error": "4.0.5",
-        "@speclynx/apidom-ns-json-schema-2019-09": "4.0.5",
-        "@speclynx/apidom-traverse": "4.0.5",
+        "@speclynx/apidom-core": "4.7.1",
+        "@speclynx/apidom-datamodel": "4.7.1",
+        "@speclynx/apidom-error": "4.7.1",
+        "@speclynx/apidom-ns-json-schema-2019-09": "4.7.1",
+        "@speclynx/apidom-traverse": "4.7.1",
         "ramda": "~0.32.0",
         "ramda-adjunct": "^6.0.0",
         "ts-mixer": "^6.0.4"
       }
     },
     "node_modules/@speclynx/apidom-ns-json-schema-draft-4": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-json-schema-draft-4/-/apidom-ns-json-schema-draft-4-4.0.5.tgz",
-      "integrity": "sha512-rg+jOhGHZky89l3iMvRYEBaBpMre6/7AWIrKswnaZcndQl5gjzWJQijRqoj1dk1rZmLQ8alXG45N+tNIMpcYBQ==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-json-schema-draft-4/-/apidom-ns-json-schema-draft-4-4.7.1.tgz",
+      "integrity": "sha512-VmXuXqHobZeqs4sHrqW30qckwObt0JTCMcZXPG5xNjiyS5TLMJu4AwWjUP90/HTVHaKgI1MZ4sZbikOO3dID9A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.0.5",
-        "@speclynx/apidom-datamodel": "4.0.5",
-        "@speclynx/apidom-traverse": "4.0.5",
+        "@speclynx/apidom-core": "4.7.1",
+        "@speclynx/apidom-datamodel": "4.7.1",
+        "@speclynx/apidom-traverse": "4.7.1",
         "ramda": "~0.32.0",
         "ramda-adjunct": "^6.0.0",
         "ts-mixer": "^6.0.4"
       }
     },
     "node_modules/@speclynx/apidom-ns-json-schema-draft-6": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-json-schema-draft-6/-/apidom-ns-json-schema-draft-6-4.0.5.tgz",
-      "integrity": "sha512-Jw0rT65f1qss4t9DAznfhGbxIQ8NAeGzv7+m54VBOwZVAqfAQ5Wtibq4dECkg0biq0wbNDUFswclNYsgQJmSug==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-json-schema-draft-6/-/apidom-ns-json-schema-draft-6-4.7.1.tgz",
+      "integrity": "sha512-csQuiuYv76EQzCU2u5bEc3Y2aoBChjeaswGB6AW9TC7XIamLecUKsoFWrlSMXs7fJvwPf4zWBAwE1lhx7jYPJw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.0.5",
-        "@speclynx/apidom-datamodel": "4.0.5",
-        "@speclynx/apidom-error": "4.0.5",
-        "@speclynx/apidom-ns-json-schema-draft-4": "4.0.5",
-        "@speclynx/apidom-traverse": "4.0.5",
+        "@speclynx/apidom-core": "4.7.1",
+        "@speclynx/apidom-datamodel": "4.7.1",
+        "@speclynx/apidom-error": "4.7.1",
+        "@speclynx/apidom-ns-json-schema-draft-4": "4.7.1",
+        "@speclynx/apidom-traverse": "4.7.1",
         "ramda": "~0.32.0",
         "ramda-adjunct": "^6.0.0",
         "ts-mixer": "^6.0.4"
       }
     },
     "node_modules/@speclynx/apidom-ns-json-schema-draft-7": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-json-schema-draft-7/-/apidom-ns-json-schema-draft-7-4.0.5.tgz",
-      "integrity": "sha512-0BBzgV7wnZqLkLh4lDTEkpYuhDPacqIUtxfr/bODL0pEgk2O9qlgun4ozPX5cNy+/NIvH6k7koD+efHgEblPPg==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-json-schema-draft-7/-/apidom-ns-json-schema-draft-7-4.7.1.tgz",
+      "integrity": "sha512-1pHmw+tM9JTjCRCtaDemvhFg9AvG769EpFsKATiwdcxpsPj2TUTcV9dlnEb9IexQModdEYjxuvdc112bpHXQxA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.0.5",
-        "@speclynx/apidom-datamodel": "4.0.5",
-        "@speclynx/apidom-error": "4.0.5",
-        "@speclynx/apidom-ns-json-schema-draft-6": "4.0.5",
-        "@speclynx/apidom-traverse": "4.0.5",
+        "@speclynx/apidom-core": "4.7.1",
+        "@speclynx/apidom-datamodel": "4.7.1",
+        "@speclynx/apidom-error": "4.7.1",
+        "@speclynx/apidom-ns-json-schema-draft-6": "4.7.1",
+        "@speclynx/apidom-traverse": "4.7.1",
         "ramda": "~0.32.0",
         "ramda-adjunct": "^6.0.0",
         "ts-mixer": "^6.0.4"
       }
     },
     "node_modules/@speclynx/apidom-ns-openapi-2": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-openapi-2/-/apidom-ns-openapi-2-4.0.5.tgz",
-      "integrity": "sha512-zo5usD6MgT0Yhllfs/zH0SjiY0fxVHuMeM/avTuOr1IZpeRyQGdyzh9TuptBsSmpviZVV/ZbcIBjSOZkfzJ79A==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-openapi-2/-/apidom-ns-openapi-2-4.7.1.tgz",
+      "integrity": "sha512-5EuaaegN4H9W5suj8DU94xlTdq/ZPkSV+lIa8kNJEunUu6TxWGVqzAUvwDYS/er4S7gqfLncU8DPToE5o4wifQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.0.5",
-        "@speclynx/apidom-datamodel": "4.0.5",
-        "@speclynx/apidom-error": "4.0.5",
-        "@speclynx/apidom-ns-json-schema-draft-4": "4.0.5",
-        "@speclynx/apidom-traverse": "4.0.5",
+        "@speclynx/apidom-core": "4.7.1",
+        "@speclynx/apidom-datamodel": "4.7.1",
+        "@speclynx/apidom-error": "4.7.1",
+        "@speclynx/apidom-json-pointer": "4.7.1",
+        "@speclynx/apidom-ns-json-schema-draft-4": "4.7.1",
+        "@speclynx/apidom-traverse": "4.7.1",
         "ramda": "~0.32.0",
         "ramda-adjunct": "^6.0.0",
         "ts-mixer": "^6.0.4"
       }
     },
     "node_modules/@speclynx/apidom-ns-openapi-3-0": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-openapi-3-0/-/apidom-ns-openapi-3-0-4.0.5.tgz",
-      "integrity": "sha512-d7m6UzGzYwSRgODKIyfy1rskqXT80oTUlAjAfID8q6p3ARuMJ2v5MYCDqj80UY4sFxhAboLDeHKf24DmcuC0HQ==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-openapi-3-0/-/apidom-ns-openapi-3-0-4.7.1.tgz",
+      "integrity": "sha512-uOo/1kTo7reKo/BLgpkSRBfFjbV9eTtnDDNb6+CFq1WRUjrAjlIMsr21cDIRVDtzdElLC7grjaEhCh2YBDWGTw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.0.5",
-        "@speclynx/apidom-datamodel": "4.0.5",
-        "@speclynx/apidom-error": "4.0.5",
-        "@speclynx/apidom-ns-json-schema-draft-4": "4.0.5",
-        "@speclynx/apidom-traverse": "4.0.5",
+        "@speclynx/apidom-core": "4.7.1",
+        "@speclynx/apidom-datamodel": "4.7.1",
+        "@speclynx/apidom-error": "4.7.1",
+        "@speclynx/apidom-json-pointer": "4.7.1",
+        "@speclynx/apidom-ns-json-schema-draft-4": "4.7.1",
+        "@speclynx/apidom-traverse": "4.7.1",
         "ramda": "~0.32.0",
         "ramda-adjunct": "^6.0.0",
         "ts-mixer": "^6.0.4"
       }
     },
     "node_modules/@speclynx/apidom-ns-openapi-3-1": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-openapi-3-1/-/apidom-ns-openapi-3-1-4.0.5.tgz",
-      "integrity": "sha512-v+MnthHJ9AoDTCTnRfbd9sj0kRhM6G6bN4Sw3gareTy1+xiCnstc0JgZ40kd3yEEcZTKaghG9jm+u/zEwX3aog==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-openapi-3-1/-/apidom-ns-openapi-3-1-4.7.1.tgz",
+      "integrity": "sha512-2fJ/8WagydrHwqOc8P10WC6/x+yvsPyP1El7WLXhLtgRV9mm0z1UYDkqk5sOF+65wUxDGTAaX8jWlT2M83V4FQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.0.5",
-        "@speclynx/apidom-datamodel": "4.0.5",
-        "@speclynx/apidom-json-pointer": "4.0.5",
-        "@speclynx/apidom-ns-json-schema-2020-12": "4.0.5",
-        "@speclynx/apidom-ns-openapi-3-0": "4.0.5",
-        "@speclynx/apidom-traverse": "4.0.5",
+        "@speclynx/apidom-core": "4.7.1",
+        "@speclynx/apidom-datamodel": "4.7.1",
+        "@speclynx/apidom-json-pointer": "4.7.1",
+        "@speclynx/apidom-ns-json-schema-2020-12": "4.7.1",
+        "@speclynx/apidom-ns-openapi-3-0": "4.7.1",
+        "@speclynx/apidom-traverse": "4.7.1",
+        "ramda": "~0.32.0",
+        "ramda-adjunct": "^6.0.0",
+        "ts-mixer": "^6.0.4"
+      }
+    },
+    "node_modules/@speclynx/apidom-ns-overlay-1": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-overlay-1/-/apidom-ns-overlay-1-4.7.1.tgz",
+      "integrity": "sha512-OLIXAYnblfL1D10eT9dykoJfpoJIDw7x7wh1srcnYVz6vYhEdQYzWY9YLU0eCGF7SSPkjquLjsdqU2pRKtDiwQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.28.4",
+        "@speclynx/apidom-core": "4.7.1",
+        "@speclynx/apidom-datamodel": "4.7.1",
+        "@speclynx/apidom-traverse": "4.7.1",
         "ramda": "~0.32.0",
         "ramda-adjunct": "^6.0.0",
         "ts-mixer": "^6.0.4"
       }
     },
     "node_modules/@speclynx/apidom-parser-adapter-arazzo-json-1": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-arazzo-json-1/-/apidom-parser-adapter-arazzo-json-1-4.0.5.tgz",
-      "integrity": "sha512-THOhNfNnTRQzkQo08ZHRMqB/jMJzKkTPm7supTzrqLSmmXifa/rVDQ4cbK/xVuGS7dJedID4zh7dp/7Qwn5CEA==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-arazzo-json-1/-/apidom-parser-adapter-arazzo-json-1-4.7.1.tgz",
+      "integrity": "sha512-L1EJauUzr2s4sZQrJfqX1to70HP4r4TDbSxbNDjDMcKgW8RJikGjIHhaiezEee/vz5dW2/PbJBNqGgFapNLNlA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.0.5",
-        "@speclynx/apidom-datamodel": "4.0.5",
-        "@speclynx/apidom-ns-arazzo-1": "4.0.5",
-        "@speclynx/apidom-parser-adapter-json": "4.0.5",
+        "@speclynx/apidom-core": "4.7.1",
+        "@speclynx/apidom-datamodel": "4.7.1",
+        "@speclynx/apidom-ns-arazzo-1": "4.7.1",
+        "@speclynx/apidom-parser-adapter-json": "4.7.1",
         "ramda": "~0.32.0",
         "ramda-adjunct": "^6.0.0"
       }
     },
     "node_modules/@speclynx/apidom-parser-adapter-arazzo-yaml-1": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-arazzo-yaml-1/-/apidom-parser-adapter-arazzo-yaml-1-4.0.5.tgz",
-      "integrity": "sha512-dMPPM4j1os3n5NCIJ2LheSJDoowW4wiBRtVWuiQq2zBDCVNX01i1q1lrbQ7Z9lAS3fjjWMIu8aIwC9efeJ9zeQ==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-arazzo-yaml-1/-/apidom-parser-adapter-arazzo-yaml-1-4.7.1.tgz",
+      "integrity": "sha512-gHCbPbBqNqC1T+ecRfT28s8KdkrS9spxZc7eiihk7OMMtOGod8HZI3IrOmW810vdNe8QL4byjz8vGSg39qJu8A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.0.5",
-        "@speclynx/apidom-datamodel": "4.0.5",
-        "@speclynx/apidom-ns-arazzo-1": "4.0.5",
-        "@speclynx/apidom-parser-adapter-yaml-1-2": "4.0.5",
+        "@speclynx/apidom-core": "4.7.1",
+        "@speclynx/apidom-datamodel": "4.7.1",
+        "@speclynx/apidom-ns-arazzo-1": "4.7.1",
+        "@speclynx/apidom-parser-adapter-yaml-1-2": "4.7.1",
         "ramda": "~0.32.0",
         "ramda-adjunct": "^6.0.0"
       }
     },
     "node_modules/@speclynx/apidom-parser-adapter-asyncapi-json-2": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-asyncapi-json-2/-/apidom-parser-adapter-asyncapi-json-2-4.0.5.tgz",
-      "integrity": "sha512-ns9dwHHyvyZjH9ps6ZhBs1WhOj4Buq5VSYqDHbBOtSM8HvMqYNE497c94pkR7aRvhiwFQwsRMGleX9CT3wBTbQ==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-asyncapi-json-2/-/apidom-parser-adapter-asyncapi-json-2-4.7.1.tgz",
+      "integrity": "sha512-gMsOVFwqc7qltLINwD2L2Skk+6NMU+AyRM45W/zwT49pteY301+Nym/PcEzdQ6v28HN41DANziVPLKjISustOw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.0.5",
-        "@speclynx/apidom-datamodel": "4.0.5",
-        "@speclynx/apidom-ns-asyncapi-2": "4.0.5",
-        "@speclynx/apidom-parser-adapter-json": "4.0.5",
+        "@speclynx/apidom-core": "4.7.1",
+        "@speclynx/apidom-datamodel": "4.7.1",
+        "@speclynx/apidom-ns-asyncapi-2": "4.7.1",
+        "@speclynx/apidom-parser-adapter-json": "4.7.1",
         "ramda": "~0.32.0",
         "ramda-adjunct": "^6.0.0"
       }
     },
     "node_modules/@speclynx/apidom-parser-adapter-asyncapi-yaml-2": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-asyncapi-yaml-2/-/apidom-parser-adapter-asyncapi-yaml-2-4.0.5.tgz",
-      "integrity": "sha512-+kX7lXBzGXGy0iqYp8NK43R37BaZctpAUT3GKw9h+qcQj+IeT1WVVx/7FqdF9Z590Y7wO3a1ZcLMLkoaB9FP5Q==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-asyncapi-yaml-2/-/apidom-parser-adapter-asyncapi-yaml-2-4.7.1.tgz",
+      "integrity": "sha512-tsNHQwTxkYUy4689tb76AQ43d1zOG5F1kiyft5Jr3LJABbTAaRRGuuihF6fmEqDYTiv09T67LELDVeE2yRgSJA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.0.5",
-        "@speclynx/apidom-datamodel": "4.0.5",
-        "@speclynx/apidom-ns-asyncapi-2": "4.0.5",
-        "@speclynx/apidom-parser-adapter-yaml-1-2": "4.0.5",
+        "@speclynx/apidom-core": "4.7.1",
+        "@speclynx/apidom-datamodel": "4.7.1",
+        "@speclynx/apidom-ns-asyncapi-2": "4.7.1",
+        "@speclynx/apidom-parser-adapter-yaml-1-2": "4.7.1",
         "ramda": "~0.32.0",
         "ramda-adjunct": "^6.0.0"
       }
     },
     "node_modules/@speclynx/apidom-parser-adapter-json": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-json/-/apidom-parser-adapter-json-4.0.5.tgz",
-      "integrity": "sha512-nnXOuQ/vnfb8PPRtlLEruGFyQyU3inWpOXlaZ9tyO9VHCUMzU4dDhqKJibR3S17Hhe1ySi5wQKFsEEdBYSIKMg==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-json/-/apidom-parser-adapter-json-4.7.1.tgz",
+      "integrity": "sha512-kci2R470LVrXYgilEjZfC6LEq6gR0ZC+20yTQOd+Rfd31wOoKF8A7KP4OPeM/8Hs2lX9RxGWLOCxMT81rtsnlQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.0.5",
-        "@speclynx/apidom-datamodel": "4.0.5",
-        "@speclynx/apidom-error": "4.0.5",
-        "web-tree-sitter": "=0.26.6"
+        "@speclynx/apidom-core": "4.7.1",
+        "@speclynx/apidom-datamodel": "4.7.1",
+        "@speclynx/apidom-error": "4.7.1",
+        "web-tree-sitter": "=0.26.8"
       }
     },
     "node_modules/@speclynx/apidom-parser-adapter-openapi-json-2": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-openapi-json-2/-/apidom-parser-adapter-openapi-json-2-4.0.5.tgz",
-      "integrity": "sha512-qDWVeLriadGfed5JIgOmWyhvnkU2e8WSBVRhZPEpcgepfW/vSuFf9+Vtr4vTt32a7dQEiQTwI3YfgogU0RxcZQ==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-openapi-json-2/-/apidom-parser-adapter-openapi-json-2-4.7.1.tgz",
+      "integrity": "sha512-vB6kiLCOF6VC2ZtwMtfEi2fIBkpBq0uAK/hgMqkvlfvfc6Gr1ov1yvSALrnpqG6/H4NXIxpkMOp8tr+j0Tj35A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.0.5",
-        "@speclynx/apidom-datamodel": "4.0.5",
-        "@speclynx/apidom-ns-openapi-2": "4.0.5",
-        "@speclynx/apidom-parser-adapter-json": "4.0.5",
+        "@speclynx/apidom-core": "4.7.1",
+        "@speclynx/apidom-datamodel": "4.7.1",
+        "@speclynx/apidom-ns-openapi-2": "4.7.1",
+        "@speclynx/apidom-parser-adapter-json": "4.7.1",
         "ramda": "~0.32.0",
         "ramda-adjunct": "^6.0.0"
       }
     },
     "node_modules/@speclynx/apidom-parser-adapter-openapi-json-3-0": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-openapi-json-3-0/-/apidom-parser-adapter-openapi-json-3-0-4.0.5.tgz",
-      "integrity": "sha512-xcwv4qURho5Xtr4kyg1NvFjkARBf37oBV6Sdjn0ru1h4dzOqS2fWSoPTcoiNHx/KS4reQjuSbohWWDCWKmiVEw==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-openapi-json-3-0/-/apidom-parser-adapter-openapi-json-3-0-4.7.1.tgz",
+      "integrity": "sha512-//jSJPH7BVyLU8Dw0MpbeRp0CWIomz8LOl0hTtBC9fs9hzrTnXEVVxKXEYRc+LHpFP4DJP0uvu9KkS2+tYKUXg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.0.5",
-        "@speclynx/apidom-datamodel": "4.0.5",
-        "@speclynx/apidom-ns-openapi-3-0": "4.0.5",
-        "@speclynx/apidom-parser-adapter-json": "4.0.5",
+        "@speclynx/apidom-core": "4.7.1",
+        "@speclynx/apidom-datamodel": "4.7.1",
+        "@speclynx/apidom-ns-openapi-3-0": "4.7.1",
+        "@speclynx/apidom-parser-adapter-json": "4.7.1",
         "ramda": "~0.32.0",
         "ramda-adjunct": "^6.0.0"
       }
     },
     "node_modules/@speclynx/apidom-parser-adapter-openapi-json-3-1": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-openapi-json-3-1/-/apidom-parser-adapter-openapi-json-3-1-4.0.5.tgz",
-      "integrity": "sha512-Qpr6XUUgFGyy0CnP88dk4idIa8Xq2vg0zK2z5GdHNmU/5CYuea8LZLVaUUORVMM8XWYc+2bbmCMpdU3kTp5g6Q==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-openapi-json-3-1/-/apidom-parser-adapter-openapi-json-3-1-4.7.1.tgz",
+      "integrity": "sha512-sZysXub/is38Fg4psnMCUNF9YN/uMA5GrMgdwJcyRBaAyy9GWXHoUldPAXtvywowgehWu/urZqjiVt0d7XIpgw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.0.5",
-        "@speclynx/apidom-datamodel": "4.0.5",
-        "@speclynx/apidom-ns-openapi-3-1": "4.0.5",
-        "@speclynx/apidom-parser-adapter-json": "4.0.5",
+        "@speclynx/apidom-core": "4.7.1",
+        "@speclynx/apidom-datamodel": "4.7.1",
+        "@speclynx/apidom-ns-openapi-3-1": "4.7.1",
+        "@speclynx/apidom-parser-adapter-json": "4.7.1",
         "ramda": "~0.32.0",
         "ramda-adjunct": "^6.0.0"
       }
     },
     "node_modules/@speclynx/apidom-parser-adapter-openapi-yaml-2": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-openapi-yaml-2/-/apidom-parser-adapter-openapi-yaml-2-4.0.5.tgz",
-      "integrity": "sha512-ORHc9lYyxADoQNR0fISDpySOPjCPlQae790j1BybMe1BDY1SKGpKb1qKgvbV9dVe5N1pXl5Ps129pHroXHuBmA==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-openapi-yaml-2/-/apidom-parser-adapter-openapi-yaml-2-4.7.1.tgz",
+      "integrity": "sha512-i2iZSyP5XBn9q1vYU/BpSTgQdplno8qKH6ZM1LhmooFqd8fojR0VrpNFMu97Ft7eCgdTbPJxeHeUVewS/bz9Bg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.0.5",
-        "@speclynx/apidom-datamodel": "4.0.5",
-        "@speclynx/apidom-ns-openapi-2": "4.0.5",
-        "@speclynx/apidom-parser-adapter-yaml-1-2": "4.0.5",
+        "@speclynx/apidom-core": "4.7.1",
+        "@speclynx/apidom-datamodel": "4.7.1",
+        "@speclynx/apidom-ns-openapi-2": "4.7.1",
+        "@speclynx/apidom-parser-adapter-yaml-1-2": "4.7.1",
         "ramda": "~0.32.0",
         "ramda-adjunct": "^6.0.0"
       }
     },
     "node_modules/@speclynx/apidom-parser-adapter-openapi-yaml-3-0": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-openapi-yaml-3-0/-/apidom-parser-adapter-openapi-yaml-3-0-4.0.5.tgz",
-      "integrity": "sha512-qgMkMsu0hOmh37QH9+UaYlnOTxVf4xlChlZfFoqj/Vk2efy0YMIe035+7k5at+hpeFb7OqF7cO0VJj6uaEkFPA==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-openapi-yaml-3-0/-/apidom-parser-adapter-openapi-yaml-3-0-4.7.1.tgz",
+      "integrity": "sha512-iPZVSgPe6JObY70KYysNbR0Eglfjqx1YRdOSVrZ6c1laG8LyKWUv+x5+nvN7PnA5XrWIS0agqd6Y283AR0HNOw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.0.5",
-        "@speclynx/apidom-datamodel": "4.0.5",
-        "@speclynx/apidom-ns-openapi-3-0": "4.0.5",
-        "@speclynx/apidom-parser-adapter-yaml-1-2": "4.0.5",
+        "@speclynx/apidom-core": "4.7.1",
+        "@speclynx/apidom-datamodel": "4.7.1",
+        "@speclynx/apidom-ns-openapi-3-0": "4.7.1",
+        "@speclynx/apidom-parser-adapter-yaml-1-2": "4.7.1",
         "ramda": "~0.32.0",
         "ramda-adjunct": "^6.0.0"
       }
     },
     "node_modules/@speclynx/apidom-parser-adapter-openapi-yaml-3-1": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-openapi-yaml-3-1/-/apidom-parser-adapter-openapi-yaml-3-1-4.0.5.tgz",
-      "integrity": "sha512-nHg32rIjpv1m4Z2G+YOAAYu0xp4qjKFQKDMag8l74PsXhsa2Uqly7Bhe5Vb55jk0GCxVEtnV3hVLjT4v6Y1H+Q==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-openapi-yaml-3-1/-/apidom-parser-adapter-openapi-yaml-3-1-4.7.1.tgz",
+      "integrity": "sha512-8uCQc6z0zEl0zL0IuLFBGbJCkeyf5YnxZ3uuhDE3wswgxVGcI13YLP1gFGD8DBZg0aqjstFrIEbC2WcnlSFDQw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.0.5",
-        "@speclynx/apidom-datamodel": "4.0.5",
-        "@speclynx/apidom-ns-openapi-3-1": "4.0.5",
-        "@speclynx/apidom-parser-adapter-yaml-1-2": "4.0.5",
+        "@speclynx/apidom-core": "4.7.1",
+        "@speclynx/apidom-datamodel": "4.7.1",
+        "@speclynx/apidom-ns-openapi-3-1": "4.7.1",
+        "@speclynx/apidom-parser-adapter-yaml-1-2": "4.7.1",
+        "ramda": "~0.32.0",
+        "ramda-adjunct": "^6.0.0"
+      }
+    },
+    "node_modules/@speclynx/apidom-parser-adapter-overlay-json-1": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-overlay-json-1/-/apidom-parser-adapter-overlay-json-1-4.7.1.tgz",
+      "integrity": "sha512-RvIhxOegu0SIA4Kowa4T7snX5B33xpzkK5v2g+C+Kosk3YiGOQAZ5F48WgIgxa+l2/eP31qCbgQZxLdwCQiS6A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.28.4",
+        "@speclynx/apidom-core": "4.7.1",
+        "@speclynx/apidom-datamodel": "4.7.1",
+        "@speclynx/apidom-ns-overlay-1": "4.7.1",
+        "@speclynx/apidom-parser-adapter-json": "4.7.1",
+        "ramda": "~0.32.0",
+        "ramda-adjunct": "^6.0.0"
+      }
+    },
+    "node_modules/@speclynx/apidom-parser-adapter-overlay-yaml-1": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-overlay-yaml-1/-/apidom-parser-adapter-overlay-yaml-1-4.7.1.tgz",
+      "integrity": "sha512-QnAac+DvQqBhsLsmLcdyR8k648nbJOHCSBNTa/ZXGlDgc9ei+RmepcBcrtNEVRDawvI+ogt8gCqJwyegL+Vj3g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.28.4",
+        "@speclynx/apidom-core": "4.7.1",
+        "@speclynx/apidom-datamodel": "4.7.1",
+        "@speclynx/apidom-ns-overlay-1": "4.7.1",
+        "@speclynx/apidom-parser-adapter-yaml-1-2": "4.7.1",
         "ramda": "~0.32.0",
         "ramda-adjunct": "^6.0.0"
       }
     },
     "node_modules/@speclynx/apidom-parser-adapter-yaml-1-2": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-yaml-1-2/-/apidom-parser-adapter-yaml-1-2-4.0.5.tgz",
-      "integrity": "sha512-8wvqVmNUM1dzrIN5yf9q37kIRdDQ6Ih26VPk80et5sTMyJ5vfdncBvh95NN8dHBansf3uP+dnvvaqyVYr6jmrQ==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-yaml-1-2/-/apidom-parser-adapter-yaml-1-2-4.7.1.tgz",
+      "integrity": "sha512-CUuGAiUFT47+N93YZBQnNhYCqi1yOEF97be+yupGTjpDD8WXei1p3xsIWaJETmmxUmYUXLTMbbXNQ/5TSMxLxQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.0.5",
-        "@speclynx/apidom-datamodel": "4.0.5",
-        "@speclynx/apidom-error": "4.0.5",
+        "@speclynx/apidom-core": "4.7.1",
+        "@speclynx/apidom-datamodel": "4.7.1",
+        "@speclynx/apidom-error": "4.7.1",
         "ramda": "~0.32.0",
         "ramda-adjunct": "^6.0.0",
         "unraw": "^3.0.0",
-        "web-tree-sitter": "=0.26.6",
+        "web-tree-sitter": "=0.26.8",
         "yaml": "^2.8.2"
       }
     },
     "node_modules/@speclynx/apidom-reference": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-reference/-/apidom-reference-4.0.5.tgz",
-      "integrity": "sha512-1CG/sSNHdcXb+dj1WgNm6uXKqtEG771QnL1xLM4esPH3G0u6HcOQEg1323tDFq+suiPJExoKL+L59edipiH0Rg==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-reference/-/apidom-reference-4.7.1.tgz",
+      "integrity": "sha512-lvo9rTStfStnmCsNwYZccPlmJlfw8ijV42pefj/B4HCgLZaiV+xdqGRQ1sVPZWAfztCM17+yPajKWi5tKn2F4w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.0.5",
-        "@speclynx/apidom-datamodel": "4.0.5",
-        "@speclynx/apidom-error": "4.0.5",
-        "@speclynx/apidom-json-pointer": "4.0.5",
-        "@speclynx/apidom-ns-arazzo-1": "4.0.5",
-        "@speclynx/apidom-ns-asyncapi-2": "4.0.5",
-        "@speclynx/apidom-ns-json-schema-2020-12": "4.0.5",
-        "@speclynx/apidom-ns-openapi-2": "4.0.5",
-        "@speclynx/apidom-ns-openapi-3-0": "4.0.5",
-        "@speclynx/apidom-ns-openapi-3-1": "4.0.5",
-        "@speclynx/apidom-parser-adapter-arazzo-json-1": "4.0.5",
-        "@speclynx/apidom-parser-adapter-arazzo-yaml-1": "4.0.5",
-        "@speclynx/apidom-parser-adapter-asyncapi-json-2": "4.0.5",
-        "@speclynx/apidom-parser-adapter-asyncapi-yaml-2": "4.0.5",
-        "@speclynx/apidom-parser-adapter-json": "4.0.5",
-        "@speclynx/apidom-parser-adapter-openapi-json-2": "4.0.5",
-        "@speclynx/apidom-parser-adapter-openapi-json-3-0": "4.0.5",
-        "@speclynx/apidom-parser-adapter-openapi-json-3-1": "4.0.5",
-        "@speclynx/apidom-parser-adapter-openapi-yaml-2": "4.0.5",
-        "@speclynx/apidom-parser-adapter-openapi-yaml-3-0": "4.0.5",
-        "@speclynx/apidom-parser-adapter-openapi-yaml-3-1": "4.0.5",
-        "@speclynx/apidom-parser-adapter-yaml-1-2": "4.0.5",
-        "@speclynx/apidom-traverse": "4.0.5",
+        "@speclynx/apidom-core": "4.7.1",
+        "@speclynx/apidom-datamodel": "4.7.1",
+        "@speclynx/apidom-error": "4.7.1",
+        "@speclynx/apidom-json-pointer": "4.7.1",
+        "@speclynx/apidom-ns-arazzo-1": "4.7.1",
+        "@speclynx/apidom-ns-asyncapi-2": "4.7.1",
+        "@speclynx/apidom-ns-json-schema-2020-12": "4.7.1",
+        "@speclynx/apidom-ns-openapi-2": "4.7.1",
+        "@speclynx/apidom-ns-openapi-3-0": "4.7.1",
+        "@speclynx/apidom-ns-openapi-3-1": "4.7.1",
+        "@speclynx/apidom-ns-overlay-1": "4.7.1",
+        "@speclynx/apidom-parser-adapter-arazzo-json-1": "4.7.1",
+        "@speclynx/apidom-parser-adapter-arazzo-yaml-1": "4.7.1",
+        "@speclynx/apidom-parser-adapter-asyncapi-json-2": "4.7.1",
+        "@speclynx/apidom-parser-adapter-asyncapi-yaml-2": "4.7.1",
+        "@speclynx/apidom-parser-adapter-json": "4.7.1",
+        "@speclynx/apidom-parser-adapter-openapi-json-2": "4.7.1",
+        "@speclynx/apidom-parser-adapter-openapi-json-3-0": "4.7.1",
+        "@speclynx/apidom-parser-adapter-openapi-json-3-1": "4.7.1",
+        "@speclynx/apidom-parser-adapter-openapi-yaml-2": "4.7.1",
+        "@speclynx/apidom-parser-adapter-openapi-yaml-3-0": "4.7.1",
+        "@speclynx/apidom-parser-adapter-openapi-yaml-3-1": "4.7.1",
+        "@speclynx/apidom-parser-adapter-overlay-json-1": "4.7.1",
+        "@speclynx/apidom-parser-adapter-overlay-yaml-1": "4.7.1",
+        "@speclynx/apidom-parser-adapter-yaml-1-2": "4.7.1",
+        "@speclynx/apidom-traverse": "4.7.1",
         "@swaggerexpert/arazzo-runtime-expression": "^2.0.3",
-        "axios": "^1.13.5",
-        "picomatch": "^4.0.3",
+        "axios": "^1.15.0",
+        "picomatch": "^4.0.4",
         "process": "^0.11.10",
         "ramda": "~0.32.0",
         "ramda-adjunct": "^6.0.0"
       }
     },
     "node_modules/@speclynx/apidom-traverse": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-traverse/-/apidom-traverse-4.0.5.tgz",
-      "integrity": "sha512-Foi2MThINyoFiGMJQhZJzge+BKlZyoToeD5GF70/whgVRsUsS9Gwb1H86a3mB/Df5R0Yh1xV0SZz65CvsZXbxA==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-traverse/-/apidom-traverse-4.7.1.tgz",
+      "integrity": "sha512-cTVvGCJSk3SKCi7OHXAcJKi76IzzeZ6g/Z/eyBFaWzmjyLik7xxasmFVeU+2IsrSUCuIs8rvr1vk15Wab2h54A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-datamodel": "4.0.5",
-        "@speclynx/apidom-error": "4.0.5",
-        "@speclynx/apidom-json-path": "4.0.5",
-        "@speclynx/apidom-json-pointer": "4.0.5",
+        "@speclynx/apidom-datamodel": "4.7.1",
+        "@speclynx/apidom-error": "4.7.1",
+        "@speclynx/apidom-json-path": "4.7.1",
+        "@speclynx/apidom-json-pointer": "4.7.1",
         "ramda-adjunct": "^6.0.0"
       }
     },
@@ -1302,9 +1321,9 @@
       }
     },
     "node_modules/@stoplight/spectral-cli": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral-cli/-/spectral-cli-6.15.0.tgz",
-      "integrity": "sha512-FVeQIuqQQnnLfa8vy+oatTKUve7uU+3SaaAfdjpX/B+uB1NcfkKRJYhKT9wMEehDRaMPL5AKIRYMCFerdEbIpw==",
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-cli/-/spectral-cli-6.15.1.tgz",
+      "integrity": "sha512-ev72bUglbaZvFSMWCP5o1Iso5NGgbLZOAuedvRxYrUMey9dVCR83i033tSFvDv6cpj86HsbEmiilh8vwrY/asQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@stoplight/json": "~3.21.0",
@@ -1321,7 +1340,7 @@
         "chalk": "4.1.2",
         "fast-glob": "~3.2.12",
         "hpagent": "~1.2.0",
-        "lodash": "~4.17.21",
+        "lodash": "^4.18.1",
         "pony-cause": "^1.1.1",
         "stacktracey": "^2.1.8",
         "tslib": "^2.8.1",
@@ -1376,9 +1395,9 @@
       }
     },
     "node_modules/@stoplight/spectral-core": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral-core/-/spectral-core-1.21.0.tgz",
-      "integrity": "sha512-oj4e/FrDLUhBRocIW+lRMKlJ/q/rDZw61HkLbTFsdMd+f/FTkli2xHNB1YC6n1mrMKjjvy7XlUuFkC7XxtgbWw==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-core/-/spectral-core-1.22.0.tgz",
+      "integrity": "sha512-4hTxMDs4TFUG4/jKjaZttA65gNuV2PCKI9+51I+J4nL6ylo17DlbW+sl6byKnBuV/85HxaV33ri5fEGlp8lTSA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@stoplight/better-ajv-errors": "1.0.3",
@@ -1390,17 +1409,17 @@
         "@stoplight/types": "~13.6.0",
         "@types/es-aggregate-error": "^1.0.2",
         "@types/json-schema": "^7.0.11",
-        "ajv": "^8.17.1",
+        "ajv": "^8.18.0",
         "ajv-errors": "~3.0.0",
         "ajv-formats": "~2.1.1",
         "es-aggregate-error": "^1.0.7",
+        "expr-eval-fork": "^3.0.1",
         "jsonpath-plus": "^10.3.0",
-        "lodash": "~4.17.23",
+        "lodash": "^4.18.1",
         "lodash.topath": "^4.5.2",
-        "minimatch": "3.1.2",
+        "minimatch": "^3.1.4",
         "nimma": "0.2.3",
         "pony-cause": "^1.1.1",
-        "simple-eval": "1.0.1",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -1438,9 +1457,9 @@
       }
     },
     "node_modules/@stoplight/spectral-core/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -1448,9 +1467,9 @@
       }
     },
     "node_modules/@stoplight/spectral-core/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -1499,9 +1518,9 @@
       }
     },
     "node_modules/@stoplight/spectral-functions": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral-functions/-/spectral-functions-1.10.1.tgz",
-      "integrity": "sha512-obu8ZfoHxELOapfGsCJixKZXZcffjg+lSoNuttpmUFuDzVLT3VmH8QkPXfOGOL5Pz80BR35ClNAToDkdnYIURg==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-functions/-/spectral-functions-1.10.2.tgz",
+      "integrity": "sha512-PIfPUgTRo8EtAnL1MIrzhHoUuojSaE8shGSMaHS3BxGyc8d079BE5+TqJa1/WLUb9YT9JQnZ0Aj4xfi8NcJOIw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@stoplight/better-ajv-errors": "1.0.3",
@@ -1509,11 +1528,11 @@
         "@stoplight/spectral-core": "^1.19.4",
         "@stoplight/spectral-formats": "^1.8.1",
         "@stoplight/spectral-runtime": "^1.1.2",
-        "ajv": "^8.17.1",
+        "ajv": "^8.18.0",
         "ajv-draft-04": "~1.0.0",
         "ajv-errors": "~3.0.0",
         "ajv-formats": "~2.1.1",
-        "lodash": "~4.17.21",
+        "lodash": "^4.18.1",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -1582,9 +1601,9 @@
       }
     },
     "node_modules/@stoplight/spectral-ruleset-bundler": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral-ruleset-bundler/-/spectral-ruleset-bundler-1.6.3.tgz",
-      "integrity": "sha512-AQFRO6OCKg8SZJUupnr3+OzI1LrMieDTEUHsYgmaRpNiDRPvzImE3bzM1KyQg99q58kTQyZ8kpr7sG8Lp94RRA==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-ruleset-bundler/-/spectral-ruleset-bundler-1.7.0.tgz",
+      "integrity": "sha512-PpIdj5Wje0T7ktxY8EUzBWLU0+mGGQHznT8nlQxTMnRhWLNYsm6HvSZDXLtMi+86yqvTuf7loJy6JvLBDzHGAA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@rollup/plugin-commonjs": "~22.0.2",
@@ -1600,7 +1619,7 @@
         "@stoplight/types": "^13.6.0",
         "@types/node": "*",
         "pony-cause": "1.1.1",
-        "rollup": "~2.79.2",
+        "rollup": "~2.80.0",
         "tslib": "^2.8.1",
         "validate-npm-package-name": "3.0.0"
       },
@@ -1655,9 +1674,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@stoplight/spectral-rulesets": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral-rulesets/-/spectral-rulesets-1.22.0.tgz",
-      "integrity": "sha512-l2EY2jiKKLsvnPfGy+pXC0LeGsbJzcQP5G/AojHgf+cwN//VYxW1Wvv4WKFx/CLmLxc42mJYF2juwWofjWYNIQ==",
+      "version": "1.22.1",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-rulesets/-/spectral-rulesets-1.22.1.tgz",
+      "integrity": "sha512-DaaQJioKuYkRsOuKIJfX2ek7G7f6OCU3CI3K7ABaOcTFMiHj29SJLDdb04mCjXZFXMlXHjmCl2ZpKW6heieXpw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@asyncapi/specs": "^6.8.0",
@@ -1669,11 +1688,11 @@
         "@stoplight/spectral-runtime": "^1.1.2",
         "@stoplight/types": "^13.6.0",
         "@types/json-schema": "^7.0.7",
-        "ajv": "^8.17.1",
+        "ajv": "^8.18.0",
         "ajv-formats": "~2.1.1",
         "json-schema-traverse": "^1.0.0",
         "leven": "3.1.0",
-        "lodash": "~4.17.21",
+        "lodash": "^4.18.1",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -1787,9 +1806,9 @@
       }
     },
     "node_modules/@swaggerexpert/jsonpath": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@swaggerexpert/jsonpath/-/jsonpath-4.0.3.tgz",
-      "integrity": "sha512-ttXX1KATYGCdQbvXOAq7WN9WQ5Dx2Wshgj2M1dG4oARyPH5puxCVsAzB5qsz/2K08cJ6kNY6iOk6AlSj5zK/8g==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@swaggerexpert/jsonpath/-/jsonpath-4.0.4.tgz",
+      "integrity": "sha512-jMUead/P3XFSy+XzlIkxlwnPX59MikrV99t+WzRr3rnmrDuS5VdsTbGJYdCd9ztH37WplDEPP+16+O+eVJmrkw==",
       "license": "Apache-2.0",
       "dependencies": {
         "apg-lite": "^1.0.5"
@@ -1885,6 +1904,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -2070,14 +2090,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -2483,13 +2503,10 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.2.tgz",
-      "integrity": "sha512-6obghkliLdmKa56xdbLOpUZ43pAR6xFy1uOrxBaIDjT+yaRuuybLjGS9eVBoSR/UPU5fq3OXClEHLJNGvbxKpQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
-      "engines": {
-        "node": ">=20"
-      },
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
@@ -2714,6 +2731,15 @@
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
     },
+    "node_modules/expr-eval-fork": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/expr-eval-fork/-/expr-eval-fork-3.0.3.tgz",
+      "integrity": "sha512-BhC+hbc5lIVjygr840n5DEkW3MQq7H9o+mc1/N7Z5uIiCFVyESLL5DIE7LNq4CYUNxy+XjA+3jRrL/h0Kt2xcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2821,9 +2847,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -3694,6 +3720,7 @@
       "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -3791,9 +3818,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.topath": {
@@ -3991,6 +4018,7 @@
       "resolved": "https://registry.npmjs.org/mobx/-/mobx-6.15.0.tgz",
       "integrity": "sha512-UczzB+0nnwGotYSgllfARAqWCJ5e/skuV2K/l+Zyck/H6pJIhLXuBnz+6vn2i211o7DtbE78HQtsYEKICHGI+g==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mobx"
@@ -4306,13 +4334,13 @@
       }
     },
     "node_modules/openapi-sampler": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/openapi-sampler/-/openapi-sampler-1.7.0.tgz",
-      "integrity": "sha512-fWq32F5vqGpgRJYIarC/9Y1wC9tKnRDcCOjsDJ7MIcSv2HsE7kNifcXIZ8FVtNStBUWxYrEk/MKqVF0SwZ5gog==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/openapi-sampler/-/openapi-sampler-1.7.2.tgz",
+      "integrity": "sha512-OKytvqB5XIaTgA9xtw8W8UTar+uymW2xPVpFN0NihMtuHPdPTGxBEhGnfFnJW5g/gOSIvkP+H0Xh3XhVI9/n7g==",
       "license": "MIT",
       "dependencies": {
         "@types/json-schema": "^7.0.7",
-        "fast-xml-parser": "^5.3.4",
+        "fast-xml-parser": "^5.5.1",
         "json-pointer": "0.6.2"
       }
     },
@@ -4524,9 +4552,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -4548,10 +4576,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -4578,6 +4609,7 @@
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.32.0.tgz",
       "integrity": "sha512-GQWAHhxhxWBWA8oIBr1XahFVjQ9Fic6MK9ikijfd4TZHfE2+urfk+irVlR5VOn48uwMgM+loRRBJd6Yjsbc0zQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ramda"
@@ -4613,6 +4645,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4622,6 +4655,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -4849,10 +4883,11 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.79.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz",
-      "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
+      "version": "2.80.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.80.0.tgz",
+      "integrity": "sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -5176,18 +5211,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/simple-eval": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/simple-eval/-/simple-eval-1.0.1.tgz",
-      "integrity": "sha512-LH7FpTAkeD+y5xQC4fzS+tFtaNlvt3Ib1zKzvhjv/Y+cioV4zIuw4IZr2yhRLu67CWL7FR9/6KXKnjRoZTvGGQ==",
-      "license": "MIT",
-      "dependencies": {
-        "jsep": "^1.3.6"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/simple-websocket": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/simple-websocket/-/simple-websocket-9.1.0.tgz",
@@ -5385,6 +5408,7 @@
       "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.3.9.tgz",
       "integrity": "sha512-J72R4ltw0UBVUlEjTzI0gg2STOqlI9JBhQOL4Dxt7aJOnnSesy0qJDn4PYfMCafk9cWOaVg129Pesl5o+DIh0Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emotion/is-prop-valid": "1.4.0",
         "@emotion/unitless": "0.10.0",
@@ -5636,9 +5660,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
-      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
+      "version": "6.24.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.0.tgz",
+      "integrity": "sha512-lVLNosgqo5EkGqh5XUDhGfsMSoO8K0BAN0TyJLvwNRSl4xWGZlCVYsAIpa/OpA3TvmnM01GWcoKmc3ZWo5wKKA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"
@@ -5717,9 +5741,9 @@
       "license": "MIT"
     },
     "node_modules/web-tree-sitter": {
-      "version": "0.26.6",
-      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.26.6.tgz",
-      "integrity": "sha512-fSPR7VBW/fZQdUSp/bXTDLT+i/9dwtbnqgEBMzowrM4U3DzeCwDbY3MKo0584uQxID4m/1xpLflrlT/rLIRPew==",
+      "version": "0.26.8",
+      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.26.8.tgz",
+      "integrity": "sha512-4sUwi7ZyOrIk5KLgYLkc2A/F0LFMQnBhfb+2Cdl7ik4ePJ6JD+fk4ofI2sA5eGawBKBaK4Vntt7Ww5KcEsay4A==",
       "license": "MIT"
     },
     "node_modules/webidl-conversions": {
@@ -5934,28 +5958,28 @@
       "name": "@jentic/openapi-bundler-redocly",
       "version": "0.1.0",
       "dependencies": {
-        "@redocly/cli": "=2.20.0"
+        "@redocly/cli": "=2.28.0"
       }
     },
     "packages/jentic-openapi-validator-redocly": {
       "name": "@jentic/openapi-validator-redocly",
       "version": "0.1.0",
       "dependencies": {
-        "@redocly/cli": "=2.20.0"
+        "@redocly/cli": "=2.28.0"
       }
     },
     "packages/jentic-openapi-validator-speclynx": {
       "name": "@jentic/openapi-validator-speclynx",
       "version": "0.1.0",
       "dependencies": {
-        "@speclynx/apidom-core": "4.0.5",
-        "@speclynx/apidom-datamodel": "4.0.5",
-        "@speclynx/apidom-json-path": "4.0.5",
-        "@speclynx/apidom-json-pointer": "4.0.5",
-        "@speclynx/apidom-ns-openapi-3-0": "4.0.5",
-        "@speclynx/apidom-ns-openapi-3-1": "4.0.5",
-        "@speclynx/apidom-reference": "4.0.5",
-        "@speclynx/apidom-traverse": "4.0.5",
+        "@speclynx/apidom-core": "4.7.1",
+        "@speclynx/apidom-datamodel": "4.7.1",
+        "@speclynx/apidom-json-path": "4.7.1",
+        "@speclynx/apidom-json-pointer": "4.7.1",
+        "@speclynx/apidom-ns-openapi-3-0": "4.7.1",
+        "@speclynx/apidom-ns-openapi-3-1": "4.7.1",
+        "@speclynx/apidom-reference": "4.7.1",
+        "@speclynx/apidom-traverse": "4.7.1",
         "commander": "^14.0.2",
         "vscode-languageserver-types": "^3.17.5"
       },
@@ -5967,7 +5991,7 @@
       "name": "@jentic/openapi-validator-spectral",
       "version": "0.1.0",
       "dependencies": {
-        "@stoplight/spectral-cli": "6.15.0"
+        "@stoplight/spectral-cli": "6.15.1"
       }
     }
   }

--- a/packages/jentic-openapi-transformer-redocly/README.md
+++ b/packages/jentic-openapi-transformer-redocly/README.md
@@ -26,7 +26,7 @@ pip install jentic-openapi-transformer-redocly
 The Redocly CLI will be automatically downloaded via npx on first use, or you can install it globally:
 
 ```bash
-npm install -g @redocly/cli@2.15.1
+npm install -g @redocly/cli@2.28.0
 ```
 
 ## Quick Start
@@ -126,7 +126,7 @@ uv run --package jentic-openapi-transformer-redocly pytest packages/jentic-opena
 class RedoclyBundlerBackend(BaseBundlerBackend):
     def __init__(
             self,
-            redocly_path: str = "npx --yes @redocly/cli@2.20.0",
+            redocly_path: str = "npx --yes @redocly/cli@2.28.0",
             timeout: float = 600.0,
             allowed_base_dir: str | Path | None = None,
     ) -> None

--- a/packages/jentic-openapi-transformer-redocly/package.json
+++ b/packages/jentic-openapi-transformer-redocly/package.json
@@ -4,6 +4,6 @@
   "description": "OpenAPI bundler using Redocly CLI for jentic-openapi-tools",
   "private": true,
   "dependencies": {
-    "@redocly/cli": "=2.20.0"
+    "@redocly/cli": "=2.28.0"
   }
 }

--- a/packages/jentic-openapi-transformer-redocly/src/jentic/apitools/openapi/transformer/bundler/backends/redocly/__init__.py
+++ b/packages/jentic-openapi-transformer-redocly/src/jentic/apitools/openapi/transformer/bundler/backends/redocly/__init__.py
@@ -18,7 +18,7 @@ __all__ = ["RedoclyBundlerBackend"]
 class RedoclyBundlerBackend(BaseBundlerBackend):
     def __init__(
         self,
-        redocly_path: str = "npx --yes @redocly/cli@2.20.0",
+        redocly_path: str = "npx --yes @redocly/cli@2.28.0",
         timeout: float = 600.0,
         allowed_base_dir: str | Path | None = None,
     ):
@@ -26,7 +26,7 @@ class RedoclyBundlerBackend(BaseBundlerBackend):
         Initialize the RedoclyBundler.
 
         Args:
-            redocly_path: Path to the redocly CLI executable (default: "npx --yes @redocly/cli@2.20.0").
+            redocly_path: Path to the redocly CLI executable (default: "npx --yes @redocly/cli@2.28.0").
                 Uses shell-safe parsing to handle quoted arguments properly.
             timeout: Maximum time in seconds to wait for Redocly CLI execution (default: 600.0)
             allowed_base_dir: Optional base directory for path security validation.

--- a/packages/jentic-openapi-transformer-redocly/tests/conftest.py
+++ b/packages/jentic-openapi-transformer-redocly/tests/conftest.py
@@ -79,7 +79,7 @@ def redocly_cli_available() -> bool:
     """Check if Redocly CLI is available on the system."""
     try:
         result = subprocess.run(
-            ["npx", "--yes", "@redocly/cli@2.20.0", "--version"], capture_output=True, timeout=10
+            ["npx", "--yes", "@redocly/cli@2.28.0", "--version"], capture_output=True, timeout=10
         )
         return result.returncode == 0
     except (subprocess.TimeoutExpired, FileNotFoundError):
@@ -98,7 +98,7 @@ def pytest_runtest_setup(item):
     if item.get_closest_marker("requires_redocly_cli"):
         try:
             result = subprocess.run(
-                ["npx", "--yes", "@redocly/cli@2.20.0", "--version"],
+                ["npx", "--yes", "@redocly/cli@2.28.0", "--version"],
                 capture_output=True,
                 timeout=10,
             )

--- a/packages/jentic-openapi-transformer-redocly/tests/test_redocly_bundle.py
+++ b/packages/jentic-openapi-transformer-redocly/tests/test_redocly_bundle.py
@@ -76,7 +76,7 @@ class TestRedoclyBundlerUnit:
     def test_init_with_defaults(self):
         """Test RedoclyBundlerBackend initialization with default values."""
         bundler = RedoclyBundlerBackend()
-        assert bundler.redocly_path == "npx --yes @redocly/cli@2.20.0"
+        assert bundler.redocly_path == "npx --yes @redocly/cli@2.28.0"
         assert bundler.timeout == 600.0
 
     def test_init_with_custom_path(self, redocly_bundler_with_custom_path: RedoclyBundlerBackend):

--- a/packages/jentic-openapi-transformer/tests/conftest.py
+++ b/packages/jentic-openapi-transformer/tests/conftest.py
@@ -208,7 +208,7 @@ def redocly_cli_available() -> bool:
     """Check if Redocly CLI is available on the system."""
     try:
         result = subprocess.run(
-            ["npx", "--yes", "@redocly/cli@2.19.0", "--version"], capture_output=True, timeout=10
+            ["npx", "--yes", "@redocly/cli@2.28.0", "--version"], capture_output=True, timeout=10
         )
         return result.returncode == 0
     except (subprocess.TimeoutExpired, FileNotFoundError):
@@ -227,7 +227,7 @@ def pytest_runtest_setup(item):
     if item.get_closest_marker("requires_redocly_cli"):
         try:
             result = subprocess.run(
-                ["npx", "--yes", "@redocly/cli@2.19.0", "--version"],
+                ["npx", "--yes", "@redocly/cli@2.28.0", "--version"],
                 capture_output=True,
                 timeout=10,
             )

--- a/packages/jentic-openapi-validator-redocly/README.md
+++ b/packages/jentic-openapi-validator-redocly/README.md
@@ -26,7 +26,7 @@ pip install jentic-openapi-validator-redocly
 The Redocly CLI will be automatically downloaded via npx on first use, or you can install it globally:
 
 ```bash
-npm install -g @redocly/cli@2.20.0
+npm install -g @redocly/cli@2.28.0
 ```
 
 ## Quick Start
@@ -72,7 +72,7 @@ print(f"Document is valid: {result.valid}")
 validator = RedoclyValidatorBackend(redocly_path="/usr/local/bin/redocly")
 
 # Use specific version via npx
-validator = RedoclyValidatorBackend(redocly_path="npx --yes @redocly/cli@2.20.0")
+validator = RedoclyValidatorBackend(redocly_path="npx --yes @redocly/cli@2.28.0")
 ```
 
 ### Custom Rulesets
@@ -243,7 +243,7 @@ uv run --package jentic-openapi-validator-redocly pytest packages/jentic-openapi
 class RedoclyValidatorBackend(BaseValidatorBackend):
     def __init__(
             self,
-            redocly_path: str = "npx --yes @redocly/cli@2.20.0",
+            redocly_path: str = "npx --yes @redocly/cli@2.28.0",
             ruleset_path: str | None = None,
             timeout: float = 600.0,
             allowed_base_dir: str | Path | None = None,

--- a/packages/jentic-openapi-validator-redocly/package.json
+++ b/packages/jentic-openapi-validator-redocly/package.json
@@ -4,6 +4,6 @@
   "description": "OpenAPI validator using Redocly for jentic-openapi-tools",
   "private": true,
   "dependencies": {
-    "@redocly/cli": "=2.20.0"
+    "@redocly/cli": "=2.28.0"
   }
 }

--- a/packages/jentic-openapi-validator-redocly/src/jentic/apitools/openapi/validator/backends/redocly/__init__.py
+++ b/packages/jentic-openapi-validator-redocly/src/jentic/apitools/openapi/validator/backends/redocly/__init__.py
@@ -34,7 +34,7 @@ ruleset_file = rulesets_files_dir.joinpath("redocly.yaml")
 class RedoclyValidatorBackend(BaseValidatorBackend):
     def __init__(
         self,
-        redocly_path: str = "npx --yes @redocly/cli@2.20.0",
+        redocly_path: str = "npx --yes @redocly/cli@2.28.0",
         ruleset_path: str | None = None,
         timeout: float = 600.0,
         allowed_base_dir: str | Path | None = None,
@@ -44,7 +44,7 @@ class RedoclyValidatorBackend(BaseValidatorBackend):
         Initialize the RedoclyValidatorBackend.
 
         Args:
-            redocly_path: Path to the redocly CLI executable (default: "npx --yes @redocly/cli@2.20.0").
+            redocly_path: Path to the redocly CLI executable (default: "npx --yes @redocly/cli@2.28.0").
                 Uses shell-safe parsing to handle quoted arguments properly.
             ruleset_path: Path to a custom ruleset file. If None, uses bundled default ruleset.
             timeout: Maximum time in seconds to wait for Redocly CLI execution (default: 600.0)

--- a/packages/jentic-openapi-validator-redocly/tests/conftest.py
+++ b/packages/jentic-openapi-validator-redocly/tests/conftest.py
@@ -86,7 +86,7 @@ def pytest_runtest_setup(item):
     if item.get_closest_marker("requires_redocly_cli"):
         try:
             result = run_subprocess(
-                ["npx", "--yes", "@redocly/cli@2.20.0", "--version"],
+                ["npx", "--yes", "@redocly/cli@2.28.0", "--version"],
                 timeout=10.0,
             )
             if result.returncode != 0:

--- a/packages/jentic-openapi-validator-redocly/tests/test_redocly_validate.py
+++ b/packages/jentic-openapi-validator-redocly/tests/test_redocly_validate.py
@@ -85,7 +85,7 @@ class TestRedoclyValidatorUnit:
     def test_initialization_with_defaults(self):
         """Test RedoclyValidator initialization with default values."""
         validator = RedoclyValidatorBackend()
-        assert validator.redocly_path == "npx --yes @redocly/cli@2.20.0"
+        assert validator.redocly_path == "npx --yes @redocly/cli@2.28.0"
         assert validator.ruleset_path is None
         assert validator.timeout == 600.0
 
@@ -103,7 +103,7 @@ class TestRedoclyValidatorUnit:
         """Test RedoclyValidator with custom timeout."""
         validator = RedoclyValidatorBackend(timeout=60.0)
         assert validator.timeout == 60.0
-        assert validator.redocly_path == "npx --yes @redocly/cli@2.20.0"  # default
+        assert validator.redocly_path == "npx --yes @redocly/cli@2.28.0"  # default
         assert validator.ruleset_path is None  # default
 
     def test_initialization_with_all_custom_parameters(self, custom_ruleset_path):

--- a/packages/jentic-openapi-validator-speclynx/src/jentic/apitools/openapi/validator/backends/speclynx/resources/package.json
+++ b/packages/jentic-openapi-validator-speclynx/src/jentic/apitools/openapi/validator/backends/speclynx/resources/package.json
@@ -14,13 +14,13 @@
   "dependencies": {
     "commander": "^14.0.2",
     "vscode-languageserver-types": "^3.17.5",
-    "@speclynx/apidom-core": "4.0.5",
-    "@speclynx/apidom-datamodel": "4.0.5",
-    "@speclynx/apidom-json-path": "4.0.5",
-    "@speclynx/apidom-json-pointer": "4.0.5",
-    "@speclynx/apidom-ns-openapi-3-0": "4.0.5",
-    "@speclynx/apidom-ns-openapi-3-1": "4.0.5",
-    "@speclynx/apidom-reference": "4.0.5",
-    "@speclynx/apidom-traverse": "4.0.5"
+    "@speclynx/apidom-core": "4.7.1",
+    "@speclynx/apidom-datamodel": "4.7.1",
+    "@speclynx/apidom-json-path": "4.7.1",
+    "@speclynx/apidom-json-pointer": "4.7.1",
+    "@speclynx/apidom-ns-openapi-3-0": "4.7.1",
+    "@speclynx/apidom-ns-openapi-3-1": "4.7.1",
+    "@speclynx/apidom-reference": "4.7.1",
+    "@speclynx/apidom-traverse": "4.7.1"
   }
 }

--- a/packages/jentic-openapi-validator-spectral/README.md
+++ b/packages/jentic-openapi-validator-spectral/README.md
@@ -72,7 +72,7 @@ print(f"Document is valid: {result.valid}")
 validator = SpectralValidatorBackend(spectral_path="/usr/local/bin/spectral")
 
 # Use specific version via npx
-validator = SpectralValidatorBackend(spectral_path="npx --yes @stoplight/spectral-cli@6.15.0")
+validator = SpectralValidatorBackend(spectral_path="npx --yes @stoplight/spectral-cli@6.15.1")
 ```
 
 ### Custom Rulesets
@@ -247,7 +247,7 @@ uv run --package jentic-openapi-validator-spectral pytest packages/jentic-openap
 class SpectralValidatorBackend(BaseValidatorBackend):
     def __init__(
             self,
-            spectral_path: str = "npx --yes @stoplight/spectral-cli@6.15.0",
+            spectral_path: str = "npx --yes @stoplight/spectral-cli@6.15.1",
             ruleset_path: str | None = None,
             timeout: float = 600.0,
             allowed_base_dir: str | Path | None = None,

--- a/packages/jentic-openapi-validator-spectral/package.json
+++ b/packages/jentic-openapi-validator-spectral/package.json
@@ -4,6 +4,6 @@
   "description": "OpenAPI validator using Spectral for jentic-openapi-tools",
   "private": true,
   "dependencies": {
-    "@stoplight/spectral-cli": "6.15.0"
+    "@stoplight/spectral-cli": "6.15.1"
   }
 }

--- a/packages/jentic-openapi-validator-spectral/src/jentic/apitools/openapi/validator/backends/spectral/__init__.py
+++ b/packages/jentic-openapi-validator-spectral/src/jentic/apitools/openapi/validator/backends/spectral/__init__.py
@@ -32,7 +32,7 @@ ruleset_file = rulesets_files_dir.joinpath("spectral.mjs")
 class SpectralValidatorBackend(BaseValidatorBackend):
     def __init__(
         self,
-        spectral_path: str = "npx --yes @stoplight/spectral-cli@6.15.0",
+        spectral_path: str = "npx --yes @stoplight/spectral-cli@6.15.1",
         ruleset_path: str | None = None,
         timeout: float = 600.0,
         allowed_base_dir: str | Path | None = None,
@@ -41,7 +41,7 @@ class SpectralValidatorBackend(BaseValidatorBackend):
         Initialize the SpectralValidatorBackend.
 
         Args:
-            spectral_path: Path to the spectral CLI executable (default: "npx --yes @stoplight/spectral-cli@6.15.0").
+            spectral_path: Path to the spectral CLI executable (default: "npx --yes @stoplight/spectral-cli@6.15.1").
                 Uses shell-safe parsing to handle quoted arguments properly.
             ruleset_path: Path to a custom ruleset file. If None, uses bundled default ruleset.
             timeout: Maximum time in seconds to wait for Spectral CLI execution (default: 600.0)

--- a/packages/jentic-openapi-validator-spectral/tests/conftest.py
+++ b/packages/jentic-openapi-validator-spectral/tests/conftest.py
@@ -80,7 +80,7 @@ def pytest_runtest_setup(item):
     if item.get_closest_marker("requires_spectral_cli"):
         try:
             result = run_subprocess(
-                ["npx", "--yes", "@stoplight/spectral-cli@6.15.0", "--version"],
+                ["npx", "--yes", "@stoplight/spectral-cli@6.15.1", "--version"],
                 timeout=10.0,
             )
             if result.returncode != 0:

--- a/packages/jentic-openapi-validator-spectral/tests/test_spectral_validate.py
+++ b/packages/jentic-openapi-validator-spectral/tests/test_spectral_validate.py
@@ -72,7 +72,7 @@ class TestSpectralValidatorUnit:
     def test_initialization_with_defaults(self):
         """Test SpectralValidator initialization with default values."""
         validator = SpectralValidatorBackend()
-        assert validator.spectral_path == "npx --yes @stoplight/spectral-cli@6.15.0"
+        assert validator.spectral_path == "npx --yes @stoplight/spectral-cli@6.15.1"
         assert validator.ruleset_path is None
         assert validator.timeout == 600.0
 
@@ -90,7 +90,7 @@ class TestSpectralValidatorUnit:
         """Test SpectralValidator with custom timeout."""
         validator = SpectralValidatorBackend(timeout=60.0)
         assert validator.timeout == 60.0
-        assert validator.spectral_path == "npx --yes @stoplight/spectral-cli@6.15.0"  # default
+        assert validator.spectral_path == "npx --yes @stoplight/spectral-cli@6.15.1"  # default
         assert validator.ruleset_path is None  # default
 
     def test_initialization_with_all_custom_parameters(self, custom_ruleset_path):

--- a/packages/jentic-openapi-validator/tests/conftest.py
+++ b/packages/jentic-openapi-validator/tests/conftest.py
@@ -164,7 +164,7 @@ def spectral_cli_available() -> bool:
     """Check if Spectral CLI is available on the system."""
     try:
         result = subprocess.run(
-            ["npx", "--yes", "@stoplight/spectral-cli@6.15.0", "--version"],
+            ["npx", "--yes", "@stoplight/spectral-cli@6.15.1", "--version"],
             capture_output=True,
             timeout=10,
         )
@@ -188,7 +188,7 @@ def pytest_runtest_setup(item):
     if item.get_closest_marker("requires_spectral_cli"):
         try:
             result = subprocess.run(
-                ["npx", "--yes", "@stoplight/spectral-cli@6.15.0", "--version"],
+                ["npx", "--yes", "@stoplight/spectral-cli@6.15.1", "--version"],
                 capture_output=True,
                 timeout=10,
             )
@@ -200,7 +200,7 @@ def pytest_runtest_setup(item):
     if item.get_closest_marker("requires_redocly_cli"):
         try:
             result = subprocess.run(
-                ["npx", "--yes", "@redocly/cli@2.19.0", "--version"],
+                ["npx", "--yes", "@redocly/cli@2.28.0", "--version"],
                 capture_output=True,
                 timeout=10,
             )


### PR DESCRIPTION
## Summary

- Update `@redocly/cli` from v2.20.0 (and stale v2.19.0 refs) to v2.28.0 across validator-redocly and transformer-redocly packages
- Update `@stoplight/spectral-cli` from v6.15.0 to v6.15.1 across validator-spectral package
- Update `@speclynx/apidom-*` from v4.0.5 to v4.7.1 in validator-speclynx, incorporating the fix from https://github.com/speclynx/apidom/releases/tag/v4.7.1

All version strings updated in source defaults, package.json files, READMEs, test conftest files, and test assertions. `package-lock.json` regenerated.

## Test plan

- [x] All 1868 tests pass (10 skipped), same results as before the update
- [x] `npm install` resolves cleanly with new versions
- [x] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)