### PR TITLE
ci(tools): add Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,42 @@
+name: Dependabot Auto-Merge
+
+on:
+  pull_request_target:
+    types: [ opened, synchronize, reopened ]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot-auto-merge:
+    name: Auto-merge non-major updates
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.ARAZZO_BUILDER_APP_ID }}
+          private-key: ${{ secrets.ARAZZO_BUILDER_PRIVATE_KEY }}
+
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v3
+        with:
+          github-token: "${{ steps.app-token.outputs.token }}"
+
+      - name: Approve PR
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Enable auto-merge for non-major updates
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that auto-approves and squash-merges non-major Dependabot PRs
- Uses a GitHub App token (`actions/create-github-app-token@v2`) for authentication
- Major version bumps are skipped and require manual review
- Relies on branch protection required status checks to gate merges until CI passes

## Test plan
- [ ] Verify `ARAZZO_BUILDER_APP_ID` and `ARAZZO_BUILDER_PRIVATE_KEY` secrets are configured
- [ ] Confirm branch protection rules require CI checks on `main`
- [ ] Wait for next Dependabot PR to validate the workflow triggers and merges correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)