### PR TITLE
ci(tools): use GitHub App token in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,18 @@ jobs:
       attestations: write # For GitHub Attestations
 
     steps:
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.ARAZZO_BUILDER_APP_ID }}
+          private-key: ${{ secrets.ARAZZO_BUILDER_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -68,13 +76,13 @@ jobs:
       - name: Semantic Release
         id: semantic_release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           echo "🚀 Running semantic release for alpha..."
 
           # Configure git for commits
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "${{ steps.app-token.outputs.app-slug }}[bot]"
+          git config user.email "${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
 
           # Run semantic-release and capture the new version
           # Use --prerelease to force alpha revision bumps on every release
@@ -144,7 +152,7 @@ jobs:
 
       - name: Create GitHub Release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           echo "🚀 Creating GitHub release..."
           VERSION=${{ steps.released_version.outputs.version }}


### PR DESCRIPTION
## Summary

- Replace `secrets.GITHUB_TOKEN` with a GitHub App token (Arazzo Builder) in the release workflow
- Use the app token for checkout, semantic release, and GitHub release creation
- Set git identity to the app's bot user via `app-slug` output

This ensures pushes made during the release can trigger downstream workflows (e.g., CI on the release commit), which `GITHUB_TOKEN` intentionally prevents.

## Test plan

- [x] Trigger a release via `workflow_dispatch` and verify it completes successfully
- [x] Confirm the release commit is attributed to `arazzo-builder[bot]`
- [x] Verify downstream workflows are triggered by the push

🤖 Generated with [Claude Code](https://claude.com/claude-code)