### PR TITLE
chore(deps): bump js and python dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -88,12 +88,6 @@
       "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
       "license": "MIT"
     },
-    "node_modules/@emotion/unitless": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
-      "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
-      "license": "MIT"
-    },
     "node_modules/@exodus/schemasafe": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@exodus/schemasafe/-/schemasafe-1.3.0.tgz",
@@ -183,6 +177,18 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -219,19 +225,18 @@
       }
     },
     "node_modules/@opentelemetry/api": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/@opentelemetry/api-logs": {
-      "version": "0.202.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.202.0.tgz",
-      "integrity": "sha512-fTBjMqKCfotFWfLzaKyhjLvyEyq5vDKTTFfBmx21btv3gvy8Lq6N5Dh2OzqeuN4DjtpSvNT1uNVfg08eD2Rfxw==",
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.214.0.tgz",
+      "integrity": "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0"
@@ -241,9 +246,9 @@
       }
     },
     "node_modules/@opentelemetry/context-async-hooks": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.0.1.tgz",
-      "integrity": "sha512-XuY23lSI3d4PEqKA+7SLtAgwqIfc6E/E9eAQWLN1vlpC53ybO3o6jW4BsXo1xvz9lYyyWItfQDDLzezER01mCw==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.6.1.tgz",
+      "integrity": "sha512-XHzhwRNkBpeP8Fs/qjGrAf9r9PRv67wkJQ/7ZPaBQQ68DYlTBBx5MF9LvPx7mhuXcDessKK2b+DcxqwpgkcivQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -253,9 +258,9 @@
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.1.tgz",
-      "integrity": "sha512-MaZk9SJIDgo1peKevlbhP6+IwIiNPNmswNL4AF0WaQJLbHXjr9SrZMgS12+iqr9ToV4ZVosCcc0f8Rg67LXjxw==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.1.tgz",
+      "integrity": "sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -268,16 +273,16 @@
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-http": {
-      "version": "0.202.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.202.0.tgz",
-      "integrity": "sha512-/hKE8DaFCJuaQqE1IxpgkcjOolUIwgi3TgHElPVKGdGRBSmJMTmN/cr6vWa55pCJIXPyhKvcMrbrya7DZ3VmzA==",
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.214.0.tgz",
+      "integrity": "sha512-kIN8nTBMgV2hXzV/a20BCFilPZdAIMYYJGSgfMMRm/Xa+07y5hRDS2Vm12A/z8Cdu3Sq++ZvJfElokX2rkgGgw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.0.1",
-        "@opentelemetry/otlp-exporter-base": "0.202.0",
-        "@opentelemetry/otlp-transformer": "0.202.0",
-        "@opentelemetry/resources": "2.0.1",
-        "@opentelemetry/sdk-trace-base": "2.0.1"
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/otlp-exporter-base": "0.214.0",
+        "@opentelemetry/otlp-transformer": "0.214.0",
+        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/sdk-trace-base": "2.6.1"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -287,13 +292,13 @@
       }
     },
     "node_modules/@opentelemetry/otlp-exporter-base": {
-      "version": "0.202.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.202.0.tgz",
-      "integrity": "sha512-nMEOzel+pUFYuBJg2znGmHJWbmvMbdX5/RhoKNKowguMbURhz0fwik5tUKplLcUtl8wKPL1y9zPnPxeBn65N0Q==",
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.214.0.tgz",
+      "integrity": "sha512-u1Gdv0/E9wP+apqWf7Wv2npXmgJtxsW2XL0TEv9FZloTZRuMBKmu8cYVXwS4Hm3q/f/3FuCnPTgiwYvIqRSpRg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.0.1",
-        "@opentelemetry/otlp-transformer": "0.202.0"
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/otlp-transformer": "0.214.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -303,18 +308,18 @@
       }
     },
     "node_modules/@opentelemetry/otlp-transformer": {
-      "version": "0.202.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.202.0.tgz",
-      "integrity": "sha512-5XO77QFzs9WkexvJQL9ksxL8oVFb/dfi9NWQSq7Sv0Efr9x3N+nb1iklP1TeVgxqJ7m1xWiC/Uv3wupiQGevMw==",
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.214.0.tgz",
+      "integrity": "sha512-DSaYcuBRh6uozfsWN3R8HsN0yDhCuWP7tOFdkUOVaWD1KVJg8m4qiLUsg/tNhTLS9HUYUcwNpwL2eroLtsZZ/w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.202.0",
-        "@opentelemetry/core": "2.0.1",
-        "@opentelemetry/resources": "2.0.1",
-        "@opentelemetry/sdk-logs": "0.202.0",
-        "@opentelemetry/sdk-metrics": "2.0.1",
-        "@opentelemetry/sdk-trace-base": "2.0.1",
-        "protobufjs": "^7.3.0"
+        "@opentelemetry/api-logs": "0.214.0",
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/sdk-logs": "0.214.0",
+        "@opentelemetry/sdk-metrics": "2.6.1",
+        "@opentelemetry/sdk-trace-base": "2.6.1",
+        "protobufjs": "^7.0.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -324,12 +329,12 @@
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.1.tgz",
-      "integrity": "sha512-dZOB3R6zvBwDKnHDTB4X1xtMArB/d324VsbiPkX/Yu0Q8T2xceRthoIVFhJdvgVM2QhGVUyX9tzwiNxGtoBJUw==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.6.1.tgz",
+      "integrity": "sha512-lID/vxSuKWXM55XhAKNoYXu9Cutoq5hFdkbTdI/zDKQktXzcWBVhNsOkiZFTMU9UtEWuGRNe0HUgmsFldIdxVA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.0.1",
+        "@opentelemetry/core": "2.6.1",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -340,14 +345,15 @@
       }
     },
     "node_modules/@opentelemetry/sdk-logs": {
-      "version": "0.202.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.202.0.tgz",
-      "integrity": "sha512-pv8QiQLQzk4X909YKm0lnW4hpuQg4zHwJ4XBd5bZiXcd9urvrJNoNVKnxGHPiDVX/GiLFvr5DMYsDBQbZCypRQ==",
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.214.0.tgz",
+      "integrity": "sha512-zf6acnScjhsaBUU22zXZ/sLWim1dfhUAbGXdMmHmNG3LfBnQ3DKsOCITb2IZwoUsNNMTogqFKBnlIPPftUgGwA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.202.0",
-        "@opentelemetry/core": "2.0.1",
-        "@opentelemetry/resources": "2.0.1"
+        "@opentelemetry/api-logs": "0.214.0",
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -357,13 +363,13 @@
       }
     },
     "node_modules/@opentelemetry/sdk-metrics": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.0.1.tgz",
-      "integrity": "sha512-wf8OaJoSnujMAHWR3g+/hGvNcsC16rf9s1So4JlMiFaFHiE4HpIA3oUh+uWZQ7CNuK8gVW/pQSkgoa5HkkOl0g==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.6.1.tgz",
+      "integrity": "sha512-9t9hJHX15meBy2NmTJxL+NJfXmnausR2xUDvE19XQce0Qi/GBtDGamU8nS1RMbdgDmhgpm3VaOu2+fiS/SfTpQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.0.1",
-        "@opentelemetry/resources": "2.0.1"
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/resources": "2.6.1"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -373,13 +379,13 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.0.1.tgz",
-      "integrity": "sha512-xYLlvk/xdScGx1aEqvxLwf6sXQLXCjk3/1SQT9X9AoN5rXRhkdvIFShuNNmtTEPRBqcsMbS4p/gJLNI2wXaDuQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.6.1.tgz",
+      "integrity": "sha512-r86ut4T1e8vNwB35CqCcKd45yzqH6/6Wzvpk2/cZB8PsPLlZFTvrh8yfOS3CYZYcUmAx4hHTZJ8AO8Dj8nrdhw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.0.1",
-        "@opentelemetry/resources": "2.0.1",
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/resources": "2.6.1",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -390,14 +396,14 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-node": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.0.1.tgz",
-      "integrity": "sha512-UhdbPF19pMpBtCWYP5lHbTogLWx9N0EBxtdagvkn5YtsAnCBZzL7SjktG+ZmupRgifsHMjwUaCCaVmqGfSADmA==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.6.1.tgz",
+      "integrity": "sha512-Hh2i4FwHWRFhnO2Q/p6svMxy8MPsNCG0uuzUY3glqm0rwM0nQvbTO1dXSp9OqQoTKXcQzaz9q1f65fsurmOhNw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/context-async-hooks": "2.0.1",
-        "@opentelemetry/core": "2.0.1",
-        "@opentelemetry/sdk-trace-base": "2.0.1"
+        "@opentelemetry/context-async-hooks": "2.6.1",
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/sdk-trace-base": "2.6.1"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -407,9 +413,9 @@
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.34.0.tgz",
-      "integrity": "sha512-aKcOkyrorBGlajjRdVoJWHTxfxO1vCNHLJVlSDaRHDIdjU+pX8IYQPvPDkYiujKLbRnWU+1TBwEt0QRgSm4SGA==",
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
+      "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
@@ -428,9 +434,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
@@ -440,13 +446,12 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
+        "@protobufjs/aspromise": "^1.1.1"
       }
     },
     "node_modules/@protobufjs/float": {
@@ -456,9 +461,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
@@ -474,9 +479,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@redocly/ajv": {
@@ -496,20 +501,19 @@
       }
     },
     "node_modules/@redocly/cli": {
-      "version": "2.28.0",
-      "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-2.28.0.tgz",
-      "integrity": "sha512-hAHtMjo4fLdLqZXtZwQqlwGnAiOzEAh7EPbE01rs9j7cewj2btOXrGQW8v6Eg3gDh+i77/DOxxazRWvZ/zAa7w==",
+      "version": "2.31.2",
+      "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-2.31.2.tgz",
+      "integrity": "sha512-MqO0I6UvB4d7VOTOrYAbVwS+AgUZ4Bxp7d2vCbUseiEYGxArvkzXtwWNLfNKryXvUrVB8kfmvLuRp7LLHFvvDA==",
       "license": "MIT",
       "dependencies": {
-        "@opentelemetry/exporter-trace-otlp-http": "0.202.0",
-        "@opentelemetry/resources": "2.0.1",
-        "@opentelemetry/sdk-trace-node": "2.0.1",
-        "@opentelemetry/semantic-conventions": "1.34.0",
-        "@redocly/cli-otel": "0.1.2",
-        "@redocly/openapi-core": "2.28.0",
-        "@redocly/respect-core": "2.28.0",
-        "abort-controller": "^3.0.0",
-        "ajv": "npm:@redocly/ajv@8.18.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.214.0",
+        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/sdk-trace-node": "2.6.1",
+        "@opentelemetry/semantic-conventions": "1.40.0",
+        "@redocly/cli-otel": "0.3.1",
+        "@redocly/openapi-core": "2.31.2",
+        "@redocly/respect-core": "2.31.2",
+        "ajv": "npm:@redocly/ajv@8.18.1",
         "ajv-formats": "^3.0.1",
         "colorette": "^1.2.0",
         "cookie": "^0.7.2",
@@ -526,7 +530,7 @@
         "semver": "^7.5.2",
         "set-cookie-parser": "^2.3.5",
         "simple-websocket": "^9.0.0",
-        "styled-components": "6.3.9",
+        "styled-components": "6.4.1",
         "ulid": "^3.0.1",
         "undici": "6.24.0",
         "yargs": "17.0.1"
@@ -541,9 +545,9 @@
       }
     },
     "node_modules/@redocly/cli-otel": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@redocly/cli-otel/-/cli-otel-0.1.2.tgz",
-      "integrity": "sha512-Bg7BoO5t1x3lVK+KhA5aGPmeXpQmdf6WtTYHhelKJCsQ+tRMiJoFAQoKHoBHAoNxXrhlS3K9lKFLHGmtxsFQfA==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@redocly/cli-otel/-/cli-otel-0.3.1.tgz",
+      "integrity": "sha512-TbC4bK2zLtU/O9I2pszHPP0rtJOvFhQmEwQ/FHxERPu71fgKG8POUDP2jSiGmsXE7NdGSHBKqnf+y9Acn2jq5g==",
       "license": "MIT",
       "dependencies": {
         "ulid": "^2.3.0"
@@ -558,24 +562,41 @@
         "ulid": "bin/cli.js"
       }
     },
+    "node_modules/@redocly/cli/node_modules/ajv": {
+      "name": "@redocly/ajv",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.18.1.tgz",
+      "integrity": "sha512-Ifm/pP/tul1qmAecpbVxCBluVE32rKfjf8gYXH4xI2gCv9mRWFhJMHzkPDM4TXlxwPQYIFegymlsy8lXz7optA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/@redocly/config": {
-      "version": "0.48.0",
-      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.48.0.tgz",
-      "integrity": "sha512-8W3wz+Q7y4e9klJWlYOvQWK5r7P2Mo589vcjtlT5coOxsyAdt53k8Vb8iAqnRiGWExbjBQmSbL2XbuU747Nf6Q==",
+      "version": "0.48.2",
+      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.48.2.tgz",
+      "integrity": "sha512-DUHthTRdj+caAQWCtJae4yzvxaUDuwQkFsZFVaAEyORd8Bt8K2wYso61jYZuR/kQZaDejfUREtQTVVZ5VYTqgw==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "2.7.2"
       }
     },
     "node_modules/@redocly/openapi-core": {
-      "version": "2.28.0",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-2.28.0.tgz",
-      "integrity": "sha512-Htpp4PsjKMgEuMT9iJu4iuFFzWCDe8FylvpGaQEA5D7jZXWv+8XvnqhpGCKN2cM/n/Uri2QfqNdw0JlKIC59sg==",
+      "version": "2.31.2",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-2.31.2.tgz",
+      "integrity": "sha512-qKXAdKTRKqWArIWbMOHOELJGgfISMFD5pK0w5CaklH8LAn5M6BbyCocqz52IqMMUIiEyAsqb46a4vtuqPhLZwg==",
       "license": "MIT",
       "dependencies": {
-        "@redocly/ajv": "^8.18.0",
-        "@redocly/config": "^0.48.0",
-        "ajv": "npm:@redocly/ajv@8.18.0",
+        "@redocly/ajv": "^8.18.1",
+        "@redocly/config": "^0.48.2",
+        "ajv": "npm:@redocly/ajv@8.18.1",
         "ajv-formats": "^3.0.1",
         "colorette": "^1.2.0",
         "js-levenshtein": "^1.1.6",
@@ -589,18 +610,35 @@
         "npm": ">=10"
       }
     },
+    "node_modules/@redocly/openapi-core/node_modules/ajv": {
+      "name": "@redocly/ajv",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.18.1.tgz",
+      "integrity": "sha512-Ifm/pP/tul1qmAecpbVxCBluVE32rKfjf8gYXH4xI2gCv9mRWFhJMHzkPDM4TXlxwPQYIFegymlsy8lXz7optA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/@redocly/respect-core": {
-      "version": "2.28.0",
-      "resolved": "https://registry.npmjs.org/@redocly/respect-core/-/respect-core-2.28.0.tgz",
-      "integrity": "sha512-svjCRzXsj/EyN7chfB9pTVYvWT1+hlOqMkZVlkrH6PqFKXAHYeP47YRW9+3omUSDBd1Ph4A4J4NBUW1PRph5+g==",
+      "version": "2.31.2",
+      "resolved": "https://registry.npmjs.org/@redocly/respect-core/-/respect-core-2.31.2.tgz",
+      "integrity": "sha512-M5zQV9M8uazCl46EVKKjWPo7M8EFNHFQOdovhqH+IfdAop5kHPi1fR1xSwrckak84XON0a+CqPU7z7+YCON0Bg==",
       "license": "MIT",
       "dependencies": {
         "@faker-js/faker": "^7.6.0",
         "@noble/hashes": "^1.8.0",
-        "@redocly/ajv": "^8.18.0",
-        "@redocly/openapi-core": "2.28.0",
-        "ajv": "npm:@redocly/ajv@8.18.0",
-        "better-ajv-errors": "^1.2.0",
+        "@redocly/ajv": "^8.18.1",
+        "@redocly/openapi-core": "2.31.2",
+        "ajv": "npm:@redocly/ajv@8.18.1",
+        "better-ajv-errors": "^2.0.3",
         "colorette": "^2.0.20",
         "json-pointer": "^0.6.2",
         "jsonpath-rfc9535": "1.3.0",
@@ -611,6 +649,23 @@
       "engines": {
         "node": ">=22.12.0 || >=20.19.0 <21.0.0",
         "npm": ">=10"
+      }
+    },
+    "node_modules/@redocly/respect-core/node_modules/ajv": {
+      "name": "@redocly/ajv",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.18.1.tgz",
+      "integrity": "sha512-Ifm/pP/tul1qmAecpbVxCBluVE32rKfjf8gYXH4xI2gCv9mRWFhJMHzkPDM4TXlxwPQYIFegymlsy8lXz7optA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/@redocly/respect-core/node_modules/colorette": {
@@ -719,496 +774,496 @@
       }
     },
     "node_modules/@speclynx/apidom-core": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-core/-/apidom-core-4.9.0.tgz",
-      "integrity": "sha512-pbnG+2SB5cjDK8T2FJ48LoZZwnSREaX5eSFjKE+J3cN9CE7U1ddi1RK4MOKiHFezdBkjZTGkglXnrjQTt9qvag==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-core/-/apidom-core-4.10.0.tgz",
+      "integrity": "sha512-sSTwLMTaJR3m09OntcJCk/vnTSei2qgr5Xj4qb8lScdLI1kQaEMJfn6iWKdVs365gkM63U+Lds1nQahA1lVhCA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-datamodel": "4.9.0",
-        "@speclynx/apidom-error": "4.9.0",
-        "@speclynx/apidom-traverse": "4.9.0",
+        "@speclynx/apidom-datamodel": "4.10.0",
+        "@speclynx/apidom-error": "4.10.0",
+        "@speclynx/apidom-traverse": "4.10.0",
         "ramda": "~0.32.0",
         "ramda-adjunct": "^6.0.0",
         "short-unique-id": "^5.3.2",
         "ts-mixer": "^6.0.4",
-        "yaml": "^2.8.2"
+        "yaml": "^2.8.4"
       }
     },
     "node_modules/@speclynx/apidom-datamodel": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-datamodel/-/apidom-datamodel-4.9.0.tgz",
-      "integrity": "sha512-OPSnKwsts/VUJm5freekRtUl+wBYqu8MWhq5NnN9JXWxqi1t8jgqRtuHFF/VSnNaOPyR5Gg3KUSFqIN8GOdyvw==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-datamodel/-/apidom-datamodel-4.10.0.tgz",
+      "integrity": "sha512-VMwKRzlyuoScoyVXaXeB9xSLJ7aY9RMETYHqHPJqk8liqXCSm+UuFD4JBMPXOYliETOaVJL66CCtpv1Lo9Riwg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-error": "4.9.0",
+        "@speclynx/apidom-error": "4.10.0",
         "ramda": "~0.32.0"
       }
     },
     "node_modules/@speclynx/apidom-error": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-error/-/apidom-error-4.9.0.tgz",
-      "integrity": "sha512-1JL/q0UgeOsJ2R0LR41v18wdk07FD9Sib61xlRtt0G8jnKBMF7IHF5eMa3aSgS4HQeATymOPlAous/zRw5BTNQ==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-error/-/apidom-error-4.10.0.tgz",
+      "integrity": "sha512-URtLF8+nL87xBG8hmEnAkyftCjFi1pUE4mbTn1W3NVHptJql9RA8ynHyrGyUE8hWdjhptn01cq6t//cqv/nuRA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.28.4"
       }
     },
     "node_modules/@speclynx/apidom-json-path": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-json-path/-/apidom-json-path-4.9.0.tgz",
-      "integrity": "sha512-RYGldNGkHVa7T/yziIT5rPGNK4J8ewjzykfK1Nmc0k42rfSnCuV5fybVX7eRk+KXW2HcUNnaZ0T+iduVuSEhEA==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-json-path/-/apidom-json-path-4.10.0.tgz",
+      "integrity": "sha512-F6BBXnvcb2eC5Kq1xJ0anhq+8GSXSvmGFV+//JiC4gg9gXf/6X8a0UBhNDVja20LMQVgmLNx5GPgRXAGcA7o7w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-datamodel": "4.9.0",
-        "@speclynx/apidom-error": "4.9.0",
+        "@speclynx/apidom-datamodel": "4.10.0",
+        "@speclynx/apidom-error": "4.10.0",
         "@swaggerexpert/jsonpath": "^4.0.4"
       }
     },
     "node_modules/@speclynx/apidom-json-pointer": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-json-pointer/-/apidom-json-pointer-4.9.0.tgz",
-      "integrity": "sha512-CwFEseeQNEvDAOB5Gc806euVEDdF2VGTFmeZHS9/OZ8EVybsG5yeYJc+9HbxWN9jKb4tu19x5uc/GNhVD2ZQsw==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-json-pointer/-/apidom-json-pointer-4.10.0.tgz",
+      "integrity": "sha512-7BTGA7FRNv8wQZEYH6rPaWf8rfd9QThLGzu9FGDNIT5RhHnrHMrkxTs2qP4UGifs9lTTbSrKleo9Bu+lANHUsQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-datamodel": "4.9.0",
-        "@speclynx/apidom-error": "4.9.0",
+        "@speclynx/apidom-datamodel": "4.10.0",
+        "@speclynx/apidom-error": "4.10.0",
         "@swaggerexpert/json-pointer": "^3.0.1"
       }
     },
     "node_modules/@speclynx/apidom-ns-arazzo-1": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-arazzo-1/-/apidom-ns-arazzo-1-4.9.0.tgz",
-      "integrity": "sha512-KE4PiDeZ9L5rRbXcq/hZILzMBoO/HHa5GOy4JMiSmAwVZw1doHtjtatXWX8EscI6ULGzvGuFpvU8ECSlx97K7w==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-arazzo-1/-/apidom-ns-arazzo-1-4.10.0.tgz",
+      "integrity": "sha512-HObK4+SzfYuRtJtksrg/Wk5P12Pq/12goR11wrRDHa5kKDeyUQGVmifyMIOu4tLyob9h6oe2J3mpwb6mRJ40hg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.9.0",
-        "@speclynx/apidom-datamodel": "4.9.0",
-        "@speclynx/apidom-ns-json-schema-2020-12": "4.9.0",
-        "@speclynx/apidom-traverse": "4.9.0",
+        "@speclynx/apidom-core": "4.10.0",
+        "@speclynx/apidom-datamodel": "4.10.0",
+        "@speclynx/apidom-ns-json-schema-2020-12": "4.10.0",
+        "@speclynx/apidom-traverse": "4.10.0",
         "ramda": "~0.32.0",
         "ramda-adjunct": "^6.0.0",
         "ts-mixer": "^6.0.4"
       }
     },
     "node_modules/@speclynx/apidom-ns-asyncapi-2": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-asyncapi-2/-/apidom-ns-asyncapi-2-4.9.0.tgz",
-      "integrity": "sha512-WCne84UH46maVKW/rMmD6mW24NJUaiEqusI8CxAK7lUdHPGEaNhsslT/6qsY0LBc+YdAdWNOgT9d5RqFRxN9Aw==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-asyncapi-2/-/apidom-ns-asyncapi-2-4.10.0.tgz",
+      "integrity": "sha512-p2xGHzaiinCYjb9ILqKQhen34KECJr7U7RhzMS8NflUWF2vxW2+bdLi6UYixwvgsViMQMfLCCgh1j2LKS1bOzw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.9.0",
-        "@speclynx/apidom-datamodel": "4.9.0",
-        "@speclynx/apidom-ns-json-schema-draft-7": "4.9.0",
-        "@speclynx/apidom-traverse": "4.9.0",
+        "@speclynx/apidom-core": "4.10.0",
+        "@speclynx/apidom-datamodel": "4.10.0",
+        "@speclynx/apidom-ns-json-schema-draft-7": "4.10.0",
+        "@speclynx/apidom-traverse": "4.10.0",
         "ramda": "~0.32.0",
         "ramda-adjunct": "^6.0.0",
         "ts-mixer": "^6.0.4"
       }
     },
     "node_modules/@speclynx/apidom-ns-json-schema-2019-09": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-json-schema-2019-09/-/apidom-ns-json-schema-2019-09-4.9.0.tgz",
-      "integrity": "sha512-JVXWfIbOMElWsdgHxKqW4z5nPhqAUgOI5PtcnsiOX7jneJ6ctG7/lqsjzNfmeCV6g0mZ9B7KaLAEi7SbtAr/8w==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-json-schema-2019-09/-/apidom-ns-json-schema-2019-09-4.10.0.tgz",
+      "integrity": "sha512-0V5W7ysh+sEmBb0emZMHBUrzJt7oH/q93OM7qgNDkl3FtQlDGLPzpQ+lVe9hkbzKlCKc4+pZihqp257Qr0UYPw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.9.0",
-        "@speclynx/apidom-datamodel": "4.9.0",
-        "@speclynx/apidom-error": "4.9.0",
-        "@speclynx/apidom-ns-json-schema-draft-6": "4.9.0",
-        "@speclynx/apidom-ns-json-schema-draft-7": "4.9.0",
-        "@speclynx/apidom-traverse": "4.9.0",
+        "@speclynx/apidom-core": "4.10.0",
+        "@speclynx/apidom-datamodel": "4.10.0",
+        "@speclynx/apidom-error": "4.10.0",
+        "@speclynx/apidom-ns-json-schema-draft-6": "4.10.0",
+        "@speclynx/apidom-ns-json-schema-draft-7": "4.10.0",
+        "@speclynx/apidom-traverse": "4.10.0",
         "ramda": "~0.32.0",
         "ramda-adjunct": "^6.0.0",
         "ts-mixer": "^6.0.4"
       }
     },
     "node_modules/@speclynx/apidom-ns-json-schema-2020-12": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-json-schema-2020-12/-/apidom-ns-json-schema-2020-12-4.9.0.tgz",
-      "integrity": "sha512-B4y4V3ZEkxg3+4Dfg+qbAgN9LqHrrmSskJIfLq9WItKxWSocUhjdxdK7InbmMtCz5tjv8XJEpHy4omoMfBEDZQ==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-json-schema-2020-12/-/apidom-ns-json-schema-2020-12-4.10.0.tgz",
+      "integrity": "sha512-M0hasmQ9LoGo4W/wjpkLuPOf5U8HWDxdNEUsEjsGawZCcTfFkG1+RiGRqbKFtMW+Fo2Q1CqnRCAvn6vM7foNuA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.9.0",
-        "@speclynx/apidom-datamodel": "4.9.0",
-        "@speclynx/apidom-error": "4.9.0",
-        "@speclynx/apidom-ns-json-schema-2019-09": "4.9.0",
-        "@speclynx/apidom-traverse": "4.9.0",
+        "@speclynx/apidom-core": "4.10.0",
+        "@speclynx/apidom-datamodel": "4.10.0",
+        "@speclynx/apidom-error": "4.10.0",
+        "@speclynx/apidom-ns-json-schema-2019-09": "4.10.0",
+        "@speclynx/apidom-traverse": "4.10.0",
         "ramda": "~0.32.0",
         "ramda-adjunct": "^6.0.0",
         "ts-mixer": "^6.0.4"
       }
     },
     "node_modules/@speclynx/apidom-ns-json-schema-draft-4": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-json-schema-draft-4/-/apidom-ns-json-schema-draft-4-4.9.0.tgz",
-      "integrity": "sha512-UcxpuyCFqdn/wckL3pkRCMOdw21Ch+EHvl0+aPmZSA+3/HCO6WXcZjh67Bk152T6kr2apFgjDokLBwrFJOgV4A==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-json-schema-draft-4/-/apidom-ns-json-schema-draft-4-4.10.0.tgz",
+      "integrity": "sha512-l3y8z7aw+veAx5SSOuGW5ksc6ALyZ3ZSdx2QeJPtAVRaBzr9PJ13j6x4P1hf6NjcXiERZ/PlahatJqMQXy3U0g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.9.0",
-        "@speclynx/apidom-datamodel": "4.9.0",
-        "@speclynx/apidom-traverse": "4.9.0",
+        "@speclynx/apidom-core": "4.10.0",
+        "@speclynx/apidom-datamodel": "4.10.0",
+        "@speclynx/apidom-traverse": "4.10.0",
         "ramda": "~0.32.0",
         "ramda-adjunct": "^6.0.0",
         "ts-mixer": "^6.0.4"
       }
     },
     "node_modules/@speclynx/apidom-ns-json-schema-draft-6": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-json-schema-draft-6/-/apidom-ns-json-schema-draft-6-4.9.0.tgz",
-      "integrity": "sha512-Lekd8+wsL0Y8HQGMOhFqyTT5yj6ul6Lb1qwLSXTsS9FdzklZ3EtuqoZv+OpgOm5Hiiai4VdVM6g8TX4aNkOpUw==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-json-schema-draft-6/-/apidom-ns-json-schema-draft-6-4.10.0.tgz",
+      "integrity": "sha512-tDUjpqvQGz9pnLVTC40wiJa4z+2m37q7AaZhYdJNAZay1uo+h++80rOO3wUah6KGY671rGMamj/sCdT7wezK6Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.9.0",
-        "@speclynx/apidom-datamodel": "4.9.0",
-        "@speclynx/apidom-error": "4.9.0",
-        "@speclynx/apidom-ns-json-schema-draft-4": "4.9.0",
-        "@speclynx/apidom-traverse": "4.9.0",
+        "@speclynx/apidom-core": "4.10.0",
+        "@speclynx/apidom-datamodel": "4.10.0",
+        "@speclynx/apidom-error": "4.10.0",
+        "@speclynx/apidom-ns-json-schema-draft-4": "4.10.0",
+        "@speclynx/apidom-traverse": "4.10.0",
         "ramda": "~0.32.0",
         "ramda-adjunct": "^6.0.0",
         "ts-mixer": "^6.0.4"
       }
     },
     "node_modules/@speclynx/apidom-ns-json-schema-draft-7": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-json-schema-draft-7/-/apidom-ns-json-schema-draft-7-4.9.0.tgz",
-      "integrity": "sha512-Fry5eKtiLBnBVPlaOqF74tUrpkVhtVtQ0iqeg5FxsFaU3xtLLlds/onAbiUzFs4mACrnJztVrpVC/qMExkX0Fw==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-json-schema-draft-7/-/apidom-ns-json-schema-draft-7-4.10.0.tgz",
+      "integrity": "sha512-PpwIb/tWbl2Nl7nw/AHm4a7qLxbES4bzBwIiJd3qEEGiNUOzhdo17OW9i/EOXHSLaCRKSBjaAyz1psfK0kbZqw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.9.0",
-        "@speclynx/apidom-datamodel": "4.9.0",
-        "@speclynx/apidom-error": "4.9.0",
-        "@speclynx/apidom-ns-json-schema-draft-6": "4.9.0",
-        "@speclynx/apidom-traverse": "4.9.0",
+        "@speclynx/apidom-core": "4.10.0",
+        "@speclynx/apidom-datamodel": "4.10.0",
+        "@speclynx/apidom-error": "4.10.0",
+        "@speclynx/apidom-ns-json-schema-draft-6": "4.10.0",
+        "@speclynx/apidom-traverse": "4.10.0",
         "ramda": "~0.32.0",
         "ramda-adjunct": "^6.0.0",
         "ts-mixer": "^6.0.4"
       }
     },
     "node_modules/@speclynx/apidom-ns-openapi-2": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-openapi-2/-/apidom-ns-openapi-2-4.9.0.tgz",
-      "integrity": "sha512-gETWMX+BIUgPt2s0FhJhiKKT2AdVxdOHYTJkCrbjycY7skbBiRAJjAe7M+wbVg8R8asTtpTYpKazoZbwMBd6eA==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-openapi-2/-/apidom-ns-openapi-2-4.10.0.tgz",
+      "integrity": "sha512-amk2l48abT7WoLMrEj/bwoZRoJn6ZKwQ2vnE5RRkI74x10MHB3yk1RbyyVFJLMd2lQ23K8bVqR36HuUPOfEe/A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.9.0",
-        "@speclynx/apidom-datamodel": "4.9.0",
-        "@speclynx/apidom-error": "4.9.0",
-        "@speclynx/apidom-json-pointer": "4.9.0",
-        "@speclynx/apidom-ns-json-schema-draft-4": "4.9.0",
-        "@speclynx/apidom-traverse": "4.9.0",
+        "@speclynx/apidom-core": "4.10.0",
+        "@speclynx/apidom-datamodel": "4.10.0",
+        "@speclynx/apidom-error": "4.10.0",
+        "@speclynx/apidom-json-pointer": "4.10.0",
+        "@speclynx/apidom-ns-json-schema-draft-4": "4.10.0",
+        "@speclynx/apidom-traverse": "4.10.0",
         "ramda": "~0.32.0",
         "ramda-adjunct": "^6.0.0",
         "ts-mixer": "^6.0.4"
       }
     },
     "node_modules/@speclynx/apidom-ns-openapi-3-0": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-openapi-3-0/-/apidom-ns-openapi-3-0-4.9.0.tgz",
-      "integrity": "sha512-HXSBLAsrs3046zFDaNEAC7t8A7qnRob733KhlPYD6z0cWnvHwfg86TBFuO8rWYChqfQYMRRQ5/RsWbYpisbFmA==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-openapi-3-0/-/apidom-ns-openapi-3-0-4.10.0.tgz",
+      "integrity": "sha512-JmZoVvq2mr7JPsOGHHr9C3Rk/bepaQX8J2qoWo7AvbG6EXcKQF2q1My7Q77QsGAoCSdbrRplTlimFxSsEMm8WA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.9.0",
-        "@speclynx/apidom-datamodel": "4.9.0",
-        "@speclynx/apidom-error": "4.9.0",
-        "@speclynx/apidom-json-pointer": "4.9.0",
-        "@speclynx/apidom-ns-json-schema-draft-4": "4.9.0",
-        "@speclynx/apidom-traverse": "4.9.0",
+        "@speclynx/apidom-core": "4.10.0",
+        "@speclynx/apidom-datamodel": "4.10.0",
+        "@speclynx/apidom-error": "4.10.0",
+        "@speclynx/apidom-json-pointer": "4.10.0",
+        "@speclynx/apidom-ns-json-schema-draft-4": "4.10.0",
+        "@speclynx/apidom-traverse": "4.10.0",
         "ramda": "~0.32.0",
         "ramda-adjunct": "^6.0.0",
         "ts-mixer": "^6.0.4"
       }
     },
     "node_modules/@speclynx/apidom-ns-openapi-3-1": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-openapi-3-1/-/apidom-ns-openapi-3-1-4.9.0.tgz",
-      "integrity": "sha512-5cG1udwqaS9D8kjpHj5VyN6sj9hn0geZLBKBoxMcD4aI6B6WXhlOGfSJO8J4R+oJVgwcsyqkwuMjpGOFRJTlPQ==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-openapi-3-1/-/apidom-ns-openapi-3-1-4.10.0.tgz",
+      "integrity": "sha512-naKHDVQ1Ajlwoirt9cYsHO3Sic1pjIyLqF1Y+qt/g3jo68sy/oPtWE1CjvHnuSqA64hpkoSL2rVgmDkwWardYw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.9.0",
-        "@speclynx/apidom-datamodel": "4.9.0",
-        "@speclynx/apidom-json-pointer": "4.9.0",
-        "@speclynx/apidom-ns-json-schema-2020-12": "4.9.0",
-        "@speclynx/apidom-ns-openapi-3-0": "4.9.0",
-        "@speclynx/apidom-traverse": "4.9.0",
+        "@speclynx/apidom-core": "4.10.0",
+        "@speclynx/apidom-datamodel": "4.10.0",
+        "@speclynx/apidom-json-pointer": "4.10.0",
+        "@speclynx/apidom-ns-json-schema-2020-12": "4.10.0",
+        "@speclynx/apidom-ns-openapi-3-0": "4.10.0",
+        "@speclynx/apidom-traverse": "4.10.0",
         "ramda": "~0.32.0",
         "ramda-adjunct": "^6.0.0",
         "ts-mixer": "^6.0.4"
       }
     },
     "node_modules/@speclynx/apidom-ns-overlay-1": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-overlay-1/-/apidom-ns-overlay-1-4.9.0.tgz",
-      "integrity": "sha512-Vm5cw42dr+DzTL5RX8ApEuOTwJp4BPJhSEuoTiGje9yITaGsQWEJJDtFP+7kRtXi6vGT6IjzMCjeaW3zRbjPWg==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-overlay-1/-/apidom-ns-overlay-1-4.10.0.tgz",
+      "integrity": "sha512-dLD2bXDHCqwUQM69ftiMoTf4FzDwBRDXQRzxVxn/pd61d20nJDRpyXuQ+Q+Vh2uZ9/k4y0v2B2ed5qv8BLZh4A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.9.0",
-        "@speclynx/apidom-datamodel": "4.9.0",
-        "@speclynx/apidom-traverse": "4.9.0",
+        "@speclynx/apidom-core": "4.10.0",
+        "@speclynx/apidom-datamodel": "4.10.0",
+        "@speclynx/apidom-traverse": "4.10.0",
         "ramda": "~0.32.0",
         "ramda-adjunct": "^6.0.0",
         "ts-mixer": "^6.0.4"
       }
     },
     "node_modules/@speclynx/apidom-parser-adapter-arazzo-json-1": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-arazzo-json-1/-/apidom-parser-adapter-arazzo-json-1-4.9.0.tgz",
-      "integrity": "sha512-JQHB63s/xwfHaGd+/wb1r2l5CPtdjnc2OStfApMWw6+/5YnhSOhxznnnv8BzAJhMqdXTWtsoessfZ9Z/siuAXQ==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-arazzo-json-1/-/apidom-parser-adapter-arazzo-json-1-4.10.0.tgz",
+      "integrity": "sha512-BFP6S7JQ5vnHglOLX+xG9647W6npemR8manJ3t1jd2Hwieeug0/olYP7xjgigRH0vyTtE6EtehZwmJs8abFdkA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.9.0",
-        "@speclynx/apidom-datamodel": "4.9.0",
-        "@speclynx/apidom-ns-arazzo-1": "4.9.0",
-        "@speclynx/apidom-parser-adapter-json": "4.9.0",
+        "@speclynx/apidom-core": "4.10.0",
+        "@speclynx/apidom-datamodel": "4.10.0",
+        "@speclynx/apidom-ns-arazzo-1": "4.10.0",
+        "@speclynx/apidom-parser-adapter-json": "4.10.0",
         "ramda": "~0.32.0",
         "ramda-adjunct": "^6.0.0"
       }
     },
     "node_modules/@speclynx/apidom-parser-adapter-arazzo-yaml-1": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-arazzo-yaml-1/-/apidom-parser-adapter-arazzo-yaml-1-4.9.0.tgz",
-      "integrity": "sha512-NpFTa8+W4JKefZHA06ampEI83PpwidHSyfjmaZscv/vY14T/hXSpJg/Txh4cLAAuQMAE0FdVQo+lG4bdrzzN9A==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-arazzo-yaml-1/-/apidom-parser-adapter-arazzo-yaml-1-4.10.0.tgz",
+      "integrity": "sha512-6xhJsPCBn5OMjPLlNm7+HDb/pPXi0dq1SBMzGEM3enakp8WU+4yUEgqm8XjbfGHWbovOBTCoMufzclsWJzrIOQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.9.0",
-        "@speclynx/apidom-datamodel": "4.9.0",
-        "@speclynx/apidom-ns-arazzo-1": "4.9.0",
-        "@speclynx/apidom-parser-adapter-yaml-1-2": "4.9.0",
+        "@speclynx/apidom-core": "4.10.0",
+        "@speclynx/apidom-datamodel": "4.10.0",
+        "@speclynx/apidom-ns-arazzo-1": "4.10.0",
+        "@speclynx/apidom-parser-adapter-yaml-1-2": "4.10.0",
         "ramda": "~0.32.0",
         "ramda-adjunct": "^6.0.0"
       }
     },
     "node_modules/@speclynx/apidom-parser-adapter-asyncapi-json-2": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-asyncapi-json-2/-/apidom-parser-adapter-asyncapi-json-2-4.9.0.tgz",
-      "integrity": "sha512-PoNcLqzH7sl4Hw514/4Up7Bc01TM5cnVLqCgzId78LlxPnTCGBLF6r6v2gpzYsytEzf0MGw21pGVxR4HLjOvlA==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-asyncapi-json-2/-/apidom-parser-adapter-asyncapi-json-2-4.10.0.tgz",
+      "integrity": "sha512-yoXVK1UooT+/TzQpvuk/CxdZaQX5nqJ7kzIouopoI9EmHQpdIvp+gtoBNumhtXKU1wAi9CQuF9ahmpzCfo9Ucw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.9.0",
-        "@speclynx/apidom-datamodel": "4.9.0",
-        "@speclynx/apidom-ns-asyncapi-2": "4.9.0",
-        "@speclynx/apidom-parser-adapter-json": "4.9.0",
+        "@speclynx/apidom-core": "4.10.0",
+        "@speclynx/apidom-datamodel": "4.10.0",
+        "@speclynx/apidom-ns-asyncapi-2": "4.10.0",
+        "@speclynx/apidom-parser-adapter-json": "4.10.0",
         "ramda": "~0.32.0",
         "ramda-adjunct": "^6.0.0"
       }
     },
     "node_modules/@speclynx/apidom-parser-adapter-asyncapi-yaml-2": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-asyncapi-yaml-2/-/apidom-parser-adapter-asyncapi-yaml-2-4.9.0.tgz",
-      "integrity": "sha512-SQ701To2aiIEdmWbuiPJGDS9UKmK/of88dde/4/NT8i/21DGnJiJmONrZo6fuhA3s91mVnkhh6dR9ftwXjGtCA==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-asyncapi-yaml-2/-/apidom-parser-adapter-asyncapi-yaml-2-4.10.0.tgz",
+      "integrity": "sha512-pHC7LCUxW+aC7PKI/HGcJOtuxUr/ZJgaSaUPxy9IBpA3ktUMw57luXW1ufNBb7aSbrkUY2E8ESwx/nJMUv4ZvA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.9.0",
-        "@speclynx/apidom-datamodel": "4.9.0",
-        "@speclynx/apidom-ns-asyncapi-2": "4.9.0",
-        "@speclynx/apidom-parser-adapter-yaml-1-2": "4.9.0",
+        "@speclynx/apidom-core": "4.10.0",
+        "@speclynx/apidom-datamodel": "4.10.0",
+        "@speclynx/apidom-ns-asyncapi-2": "4.10.0",
+        "@speclynx/apidom-parser-adapter-yaml-1-2": "4.10.0",
         "ramda": "~0.32.0",
         "ramda-adjunct": "^6.0.0"
       }
     },
     "node_modules/@speclynx/apidom-parser-adapter-json": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-json/-/apidom-parser-adapter-json-4.9.0.tgz",
-      "integrity": "sha512-BdAJktViHauhnGVNG6t2AD9QY89T0Jl9TaD4joBKcTW0YfnYPnd8rhnUYU5s8mxYpY566BJnRMz6NL22lgnGCw==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-json/-/apidom-parser-adapter-json-4.10.0.tgz",
+      "integrity": "sha512-mRjHqNMnU+GQsacmGHuRjh6mSZAHYVFz8V/ztfnlAh7xiO46nc4Ggdn+ZFawsnCRASCYz5g5j6f24QVTmO/9gQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.9.0",
-        "@speclynx/apidom-datamodel": "4.9.0",
-        "@speclynx/apidom-error": "4.9.0",
+        "@speclynx/apidom-core": "4.10.0",
+        "@speclynx/apidom-datamodel": "4.10.0",
+        "@speclynx/apidom-error": "4.10.0",
         "web-tree-sitter": "=0.26.8"
       }
     },
     "node_modules/@speclynx/apidom-parser-adapter-openapi-json-2": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-openapi-json-2/-/apidom-parser-adapter-openapi-json-2-4.9.0.tgz",
-      "integrity": "sha512-ILGOWLUwWkHAarfTRHwh+UMGLGKQcEYmsdHEdWFmtjySnrcvokCAAJfXXsJhHo/bP7HrY9oA2+pF+rIoE8cqXw==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-openapi-json-2/-/apidom-parser-adapter-openapi-json-2-4.10.0.tgz",
+      "integrity": "sha512-PNCFKrhv3ZjQjyDzLNDYCDuminGOZ1uyJh5bCwgSsyO60Lbt4zzRPbbCVyXue7UPGDI2hLQaVzuZSkt+HO04Aw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.9.0",
-        "@speclynx/apidom-datamodel": "4.9.0",
-        "@speclynx/apidom-ns-openapi-2": "4.9.0",
-        "@speclynx/apidom-parser-adapter-json": "4.9.0",
+        "@speclynx/apidom-core": "4.10.0",
+        "@speclynx/apidom-datamodel": "4.10.0",
+        "@speclynx/apidom-ns-openapi-2": "4.10.0",
+        "@speclynx/apidom-parser-adapter-json": "4.10.0",
         "ramda": "~0.32.0",
         "ramda-adjunct": "^6.0.0"
       }
     },
     "node_modules/@speclynx/apidom-parser-adapter-openapi-json-3-0": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-openapi-json-3-0/-/apidom-parser-adapter-openapi-json-3-0-4.9.0.tgz",
-      "integrity": "sha512-7EeM+I2vqgN+IKglkLFrVvWvWxtCz3s9s2wWF7rEFtf7fqN5DvIpbwJtjMGawm6Uu1l35poWRo1VPMGVYqSNfQ==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-openapi-json-3-0/-/apidom-parser-adapter-openapi-json-3-0-4.10.0.tgz",
+      "integrity": "sha512-Z6k8ZceuB709s7y0PzzdqfpDGFPLV6Ue3J5Ue17Xi5QDGsMdsUruzzjtfr4e/4l+sERHdRKLhoERfk/EoQ1/5w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.9.0",
-        "@speclynx/apidom-datamodel": "4.9.0",
-        "@speclynx/apidom-ns-openapi-3-0": "4.9.0",
-        "@speclynx/apidom-parser-adapter-json": "4.9.0",
+        "@speclynx/apidom-core": "4.10.0",
+        "@speclynx/apidom-datamodel": "4.10.0",
+        "@speclynx/apidom-ns-openapi-3-0": "4.10.0",
+        "@speclynx/apidom-parser-adapter-json": "4.10.0",
         "ramda": "~0.32.0",
         "ramda-adjunct": "^6.0.0"
       }
     },
     "node_modules/@speclynx/apidom-parser-adapter-openapi-json-3-1": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-openapi-json-3-1/-/apidom-parser-adapter-openapi-json-3-1-4.9.0.tgz",
-      "integrity": "sha512-oc+ZoAgjs6ufV1fBOMbUulqcb9OrY1v0y61imLFJTZ8Wk81I0OMUIoyKUF4YBPBbaIUCp64gVTrPjP6mmcA9QQ==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-openapi-json-3-1/-/apidom-parser-adapter-openapi-json-3-1-4.10.0.tgz",
+      "integrity": "sha512-GEGgxpzGd61HjKdDlWojdXnQn/4WoIf7SiSTifgSuthGH0GorhE6z3Og3g0cVM7NAgNrZnec3LelFAZURKm3QA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.9.0",
-        "@speclynx/apidom-datamodel": "4.9.0",
-        "@speclynx/apidom-ns-openapi-3-1": "4.9.0",
-        "@speclynx/apidom-parser-adapter-json": "4.9.0",
+        "@speclynx/apidom-core": "4.10.0",
+        "@speclynx/apidom-datamodel": "4.10.0",
+        "@speclynx/apidom-ns-openapi-3-1": "4.10.0",
+        "@speclynx/apidom-parser-adapter-json": "4.10.0",
         "ramda": "~0.32.0",
         "ramda-adjunct": "^6.0.0"
       }
     },
     "node_modules/@speclynx/apidom-parser-adapter-openapi-yaml-2": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-openapi-yaml-2/-/apidom-parser-adapter-openapi-yaml-2-4.9.0.tgz",
-      "integrity": "sha512-7WuHmC+vN697vyEy7AAFBlBTky2OY1R/YqwUdL/f6YF3fV+sq8qny/qmqeWhZ0CNJzQsdeLWatsHIKDDPXncog==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-openapi-yaml-2/-/apidom-parser-adapter-openapi-yaml-2-4.10.0.tgz",
+      "integrity": "sha512-O+L4VVV75KQ8+a6ekozXb/XWdnDHLIsTnq1nWZGLjiwWgBRUv8jf/78epvmkNQx641f9YN/BpumBVvQQgpBI8g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.9.0",
-        "@speclynx/apidom-datamodel": "4.9.0",
-        "@speclynx/apidom-ns-openapi-2": "4.9.0",
-        "@speclynx/apidom-parser-adapter-yaml-1-2": "4.9.0",
+        "@speclynx/apidom-core": "4.10.0",
+        "@speclynx/apidom-datamodel": "4.10.0",
+        "@speclynx/apidom-ns-openapi-2": "4.10.0",
+        "@speclynx/apidom-parser-adapter-yaml-1-2": "4.10.0",
         "ramda": "~0.32.0",
         "ramda-adjunct": "^6.0.0"
       }
     },
     "node_modules/@speclynx/apidom-parser-adapter-openapi-yaml-3-0": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-openapi-yaml-3-0/-/apidom-parser-adapter-openapi-yaml-3-0-4.9.0.tgz",
-      "integrity": "sha512-H3qT4Wm6exwjSrN76f98l9hp5IWFXDEcEL8k+ninRO0WvBxzmx2r9x3JihR7ka71Ge96Xo/tKwwA+KdkgwIbOA==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-openapi-yaml-3-0/-/apidom-parser-adapter-openapi-yaml-3-0-4.10.0.tgz",
+      "integrity": "sha512-hvs0Dcgqq/po9huO92SZSCMZYjWsVkv9ZWj1GTc0Mv+dT8hkQxAklQeJQl+4UQoq6IohseqkVJ8T0Rm4jSyMzA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.9.0",
-        "@speclynx/apidom-datamodel": "4.9.0",
-        "@speclynx/apidom-ns-openapi-3-0": "4.9.0",
-        "@speclynx/apidom-parser-adapter-yaml-1-2": "4.9.0",
+        "@speclynx/apidom-core": "4.10.0",
+        "@speclynx/apidom-datamodel": "4.10.0",
+        "@speclynx/apidom-ns-openapi-3-0": "4.10.0",
+        "@speclynx/apidom-parser-adapter-yaml-1-2": "4.10.0",
         "ramda": "~0.32.0",
         "ramda-adjunct": "^6.0.0"
       }
     },
     "node_modules/@speclynx/apidom-parser-adapter-openapi-yaml-3-1": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-openapi-yaml-3-1/-/apidom-parser-adapter-openapi-yaml-3-1-4.9.0.tgz",
-      "integrity": "sha512-MqhxQWQlTW5i20XiMV21jpQ603Tn+wPDPMJCJBe5Ll4GLXrbrsMOiLo8s0PwHgMS91GIgVMvLBMHVSrbKWlJ5w==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-openapi-yaml-3-1/-/apidom-parser-adapter-openapi-yaml-3-1-4.10.0.tgz",
+      "integrity": "sha512-WsP9SyBGgu7QAarg5IyVgDt4fi6jU7OT60fxQD75FzY1Wd2R8hOLAjHig7GLTynM8QOChgZYQEGFG0Yb0+oBdg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.9.0",
-        "@speclynx/apidom-datamodel": "4.9.0",
-        "@speclynx/apidom-ns-openapi-3-1": "4.9.0",
-        "@speclynx/apidom-parser-adapter-yaml-1-2": "4.9.0",
+        "@speclynx/apidom-core": "4.10.0",
+        "@speclynx/apidom-datamodel": "4.10.0",
+        "@speclynx/apidom-ns-openapi-3-1": "4.10.0",
+        "@speclynx/apidom-parser-adapter-yaml-1-2": "4.10.0",
         "ramda": "~0.32.0",
         "ramda-adjunct": "^6.0.0"
       }
     },
     "node_modules/@speclynx/apidom-parser-adapter-overlay-json-1": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-overlay-json-1/-/apidom-parser-adapter-overlay-json-1-4.9.0.tgz",
-      "integrity": "sha512-47Se46RfywUxR/jxQ5wqqnffbXtm/LQyMqZZIpQzYkDg47cXWMhDIzjM0WNBVDKAgpJdXvCdf0W37JNeBmrn8g==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-overlay-json-1/-/apidom-parser-adapter-overlay-json-1-4.10.0.tgz",
+      "integrity": "sha512-IFEiqWEvj294gKlb2inV8ZIrKOt2Ox5FaMk0XvVirUCHDwA6OBelnsuIk9dh14/Wp+xw8S/+ozv3NxD/p6V29g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.9.0",
-        "@speclynx/apidom-datamodel": "4.9.0",
-        "@speclynx/apidom-ns-overlay-1": "4.9.0",
-        "@speclynx/apidom-parser-adapter-json": "4.9.0",
+        "@speclynx/apidom-core": "4.10.0",
+        "@speclynx/apidom-datamodel": "4.10.0",
+        "@speclynx/apidom-ns-overlay-1": "4.10.0",
+        "@speclynx/apidom-parser-adapter-json": "4.10.0",
         "ramda": "~0.32.0",
         "ramda-adjunct": "^6.0.0"
       }
     },
     "node_modules/@speclynx/apidom-parser-adapter-overlay-yaml-1": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-overlay-yaml-1/-/apidom-parser-adapter-overlay-yaml-1-4.9.0.tgz",
-      "integrity": "sha512-h+sYtjb/6MRtFQCrcacbVEC89DEJQC+37vATXj4Thr9S6Eeqjj7KXLlnDDxhn5wg99e0limwGvQB4KLDr4zn3w==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-overlay-yaml-1/-/apidom-parser-adapter-overlay-yaml-1-4.10.0.tgz",
+      "integrity": "sha512-Kclu9Xa+m2cy5pp31Ku5SABaJvq+cPer42/4TGYJF/AB5nVLjoG0jVnndB1P5gViaWnrqhFj57BpTiaHcPULLA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.9.0",
-        "@speclynx/apidom-datamodel": "4.9.0",
-        "@speclynx/apidom-ns-overlay-1": "4.9.0",
-        "@speclynx/apidom-parser-adapter-yaml-1-2": "4.9.0",
+        "@speclynx/apidom-core": "4.10.0",
+        "@speclynx/apidom-datamodel": "4.10.0",
+        "@speclynx/apidom-ns-overlay-1": "4.10.0",
+        "@speclynx/apidom-parser-adapter-yaml-1-2": "4.10.0",
         "ramda": "~0.32.0",
         "ramda-adjunct": "^6.0.0"
       }
     },
     "node_modules/@speclynx/apidom-parser-adapter-yaml-1-2": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-yaml-1-2/-/apidom-parser-adapter-yaml-1-2-4.9.0.tgz",
-      "integrity": "sha512-YDR+r/XS8ZzQrT91XwPRPXHFvtXIkWIpHYzq1dJBqEgQdl0EgZJ0PtrZ4jOXmiG6DcZX69r/aXVbSQ9xjcii/A==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-yaml-1-2/-/apidom-parser-adapter-yaml-1-2-4.10.0.tgz",
+      "integrity": "sha512-FBouheDMGfeTd8XqZhN799mBTGD5LoyVZiorSNkcHI1xX8flXx9QhAS9H9d6MWa9YV9rVf72XisBh5NF+2q0OQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.9.0",
-        "@speclynx/apidom-datamodel": "4.9.0",
-        "@speclynx/apidom-error": "4.9.0",
+        "@speclynx/apidom-core": "4.10.0",
+        "@speclynx/apidom-datamodel": "4.10.0",
+        "@speclynx/apidom-error": "4.10.0",
         "ramda": "~0.32.0",
         "ramda-adjunct": "^6.0.0",
         "unraw": "^3.0.0",
         "web-tree-sitter": "=0.26.8",
-        "yaml": "^2.8.2"
+        "yaml": "^2.8.4"
       }
     },
     "node_modules/@speclynx/apidom-reference": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-reference/-/apidom-reference-4.9.0.tgz",
-      "integrity": "sha512-6B/WFQ1abDCn65EPli74XkXn9OJZe8ARDporGT/aoy9Amyb9QGy6/9hW3gVTDzRLu23a0s/X4HHOCbdRFCXD5w==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-reference/-/apidom-reference-4.10.0.tgz",
+      "integrity": "sha512-UFTwhlkHQkJooT6+BSY97KDTT3ki5EjAQ7hntaVBRW56RB38qS9MSFk4r9PXfFyes9PqtmBARcg34MNaM3SjRQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.9.0",
-        "@speclynx/apidom-datamodel": "4.9.0",
-        "@speclynx/apidom-error": "4.9.0",
-        "@speclynx/apidom-json-pointer": "4.9.0",
-        "@speclynx/apidom-ns-arazzo-1": "4.9.0",
-        "@speclynx/apidom-ns-asyncapi-2": "4.9.0",
-        "@speclynx/apidom-ns-json-schema-2020-12": "4.9.0",
-        "@speclynx/apidom-ns-openapi-2": "4.9.0",
-        "@speclynx/apidom-ns-openapi-3-0": "4.9.0",
-        "@speclynx/apidom-ns-openapi-3-1": "4.9.0",
-        "@speclynx/apidom-ns-overlay-1": "4.9.0",
-        "@speclynx/apidom-parser-adapter-arazzo-json-1": "4.9.0",
-        "@speclynx/apidom-parser-adapter-arazzo-yaml-1": "4.9.0",
-        "@speclynx/apidom-parser-adapter-asyncapi-json-2": "4.9.0",
-        "@speclynx/apidom-parser-adapter-asyncapi-yaml-2": "4.9.0",
-        "@speclynx/apidom-parser-adapter-json": "4.9.0",
-        "@speclynx/apidom-parser-adapter-openapi-json-2": "4.9.0",
-        "@speclynx/apidom-parser-adapter-openapi-json-3-0": "4.9.0",
-        "@speclynx/apidom-parser-adapter-openapi-json-3-1": "4.9.0",
-        "@speclynx/apidom-parser-adapter-openapi-yaml-2": "4.9.0",
-        "@speclynx/apidom-parser-adapter-openapi-yaml-3-0": "4.9.0",
-        "@speclynx/apidom-parser-adapter-openapi-yaml-3-1": "4.9.0",
-        "@speclynx/apidom-parser-adapter-overlay-json-1": "4.9.0",
-        "@speclynx/apidom-parser-adapter-overlay-yaml-1": "4.9.0",
-        "@speclynx/apidom-parser-adapter-yaml-1-2": "4.9.0",
-        "@speclynx/apidom-traverse": "4.9.0",
+        "@speclynx/apidom-core": "4.10.0",
+        "@speclynx/apidom-datamodel": "4.10.0",
+        "@speclynx/apidom-error": "4.10.0",
+        "@speclynx/apidom-json-pointer": "4.10.0",
+        "@speclynx/apidom-ns-arazzo-1": "4.10.0",
+        "@speclynx/apidom-ns-asyncapi-2": "4.10.0",
+        "@speclynx/apidom-ns-json-schema-2020-12": "4.10.0",
+        "@speclynx/apidom-ns-openapi-2": "4.10.0",
+        "@speclynx/apidom-ns-openapi-3-0": "4.10.0",
+        "@speclynx/apidom-ns-openapi-3-1": "4.10.0",
+        "@speclynx/apidom-ns-overlay-1": "4.10.0",
+        "@speclynx/apidom-parser-adapter-arazzo-json-1": "4.10.0",
+        "@speclynx/apidom-parser-adapter-arazzo-yaml-1": "4.10.0",
+        "@speclynx/apidom-parser-adapter-asyncapi-json-2": "4.10.0",
+        "@speclynx/apidom-parser-adapter-asyncapi-yaml-2": "4.10.0",
+        "@speclynx/apidom-parser-adapter-json": "4.10.0",
+        "@speclynx/apidom-parser-adapter-openapi-json-2": "4.10.0",
+        "@speclynx/apidom-parser-adapter-openapi-json-3-0": "4.10.0",
+        "@speclynx/apidom-parser-adapter-openapi-json-3-1": "4.10.0",
+        "@speclynx/apidom-parser-adapter-openapi-yaml-2": "4.10.0",
+        "@speclynx/apidom-parser-adapter-openapi-yaml-3-0": "4.10.0",
+        "@speclynx/apidom-parser-adapter-openapi-yaml-3-1": "4.10.0",
+        "@speclynx/apidom-parser-adapter-overlay-json-1": "4.10.0",
+        "@speclynx/apidom-parser-adapter-overlay-yaml-1": "4.10.0",
+        "@speclynx/apidom-parser-adapter-yaml-1-2": "4.10.0",
+        "@speclynx/apidom-traverse": "4.10.0",
         "@swaggerexpert/arazzo-runtime-expression": "^2.0.3",
-        "axios": "^1.15.0",
+        "axios": "^1.16.0",
         "picomatch": "^4.0.4",
         "process": "^0.11.10",
         "ramda": "~0.32.0",
@@ -1216,16 +1271,16 @@
       }
     },
     "node_modules/@speclynx/apidom-traverse": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-traverse/-/apidom-traverse-4.9.0.tgz",
-      "integrity": "sha512-bDgGIcvAKGvvqiYRDPGlzZ6BEpMEY5KUie6ctFtyYJCic3vlaFLJEo0upTWrSJt8pTMuCs3+K6SquhiKxfW0oQ==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-traverse/-/apidom-traverse-4.10.0.tgz",
+      "integrity": "sha512-xiiVVKOUGrBQ1s/K2GWbdVDRLmXEuv9qhqPb0S0HlBUP+K1srNSqB7oKDLYtVC+EQi0Lft0CYdNxAwwaRxc2xw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-datamodel": "4.9.0",
-        "@speclynx/apidom-error": "4.9.0",
-        "@speclynx/apidom-json-path": "4.9.0",
-        "@speclynx/apidom-json-pointer": "4.9.0",
+        "@speclynx/apidom-datamodel": "4.10.0",
+        "@speclynx/apidom-error": "4.10.0",
+        "@speclynx/apidom-json-path": "4.10.0",
+        "@speclynx/apidom-json-pointer": "4.10.0",
         "ramda-adjunct": "^6.0.0"
       }
     },
@@ -1321,9 +1376,9 @@
       }
     },
     "node_modules/@stoplight/spectral-cli": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral-cli/-/spectral-cli-6.15.1.tgz",
-      "integrity": "sha512-ev72bUglbaZvFSMWCP5o1Iso5NGgbLZOAuedvRxYrUMey9dVCR83i033tSFvDv6cpj86HsbEmiilh8vwrY/asQ==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-cli/-/spectral-cli-6.16.0.tgz",
+      "integrity": "sha512-P1acHIV/hDiO3w0YNUc3pD7/0q68SMAMyWVxAPUGzsAeq50lLpl0obN5j3QITMgJPhPByvBIjBV4ftkBd8nwMg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@stoplight/json": "~3.21.0",
@@ -1859,12 +1914,6 @@
       "integrity": "sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==",
       "license": "MIT"
     },
-    "node_modules/@types/stylis": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.7.tgz",
-      "integrity": "sha512-VgDNokpBoKF+wrdvhAAfS55OMQpL6QRglwTwNC3kIgBrzZxA4WsFj+2eLfEA/uMUDzBcEhYmjSbwQakn/i3ajA==",
-      "license": "MIT"
-    },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
@@ -1904,7 +1953,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -2090,14 +2138,40 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/balanced-match": {
@@ -2107,19 +2181,19 @@
       "license": "MIT"
     },
     "node_modules/better-ajv-errors": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/better-ajv-errors/-/better-ajv-errors-1.2.0.tgz",
-      "integrity": "sha512-UW+IsFycygIo7bclP9h5ugkNH8EjCSgqyFB/yQ4Hqqa1OEYDtb0uFIkYE0b6+CjkgJYVM5UKI/pJPxjYe9EZlA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/better-ajv-errors/-/better-ajv-errors-2.0.3.tgz",
+      "integrity": "sha512-t1vxUP+vYKsaYi/BbKo2K98nEAZmfi4sjwvmRT8aOPDzPJeAtLurfoIDazVkLILxO4K+Sw4YrLYnBQ46l6pePg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/code-frame": "^7.16.0",
-        "@humanwhocodes/momoa": "^2.0.2",
+        "@babel/code-frame": "^7.27.1",
+        "@humanwhocodes/momoa": "^2.0.4",
         "chalk": "^4.1.2",
-        "jsonpointer": "^5.0.0",
+        "jsonpointer": "^5.0.1",
         "leven": "^3.1.0 < 4"
       },
       "engines": {
-        "node": ">= 12.13.0"
+        "node": ">= 18.20.6"
       },
       "peerDependencies": {
         "ajv": "4.11.8 - 8"
@@ -2775,9 +2849,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -2791,9 +2865,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
-      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "funding": [
         {
           "type": "github",
@@ -2802,13 +2876,14 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.5.9",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.9.tgz",
-      "integrity": "sha512-jldvxr1MC6rtiZKgrFnDSvT8xuH+eJqxqOBThUVjYrxssYTo1avZLGql5l0a0BAERR01CadYzZ83kVEkbyDg+g==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.8.0.tgz",
+      "integrity": "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==",
       "funding": [
         {
           "type": "github",
@@ -2817,9 +2892,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.2.0",
-        "strnum": "^2.2.2"
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.2.0",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.3.0",
+        "xml-naming": "^0.1.0"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -3720,7 +3797,6 @@
       "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -3984,9 +4060,9 @@
       }
     },
     "node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -4018,7 +4094,6 @@
       "resolved": "https://registry.npmjs.org/mobx/-/mobx-6.15.0.tgz",
       "integrity": "sha512-UczzB+0nnwGotYSgllfARAqWCJ5e/skuV2K/l+Zyck/H6pJIhLXuBnz+6vn2i211o7DtbE78HQtsYEKICHGI+g==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mobx"
@@ -4079,24 +4154,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
-    },
-    "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
     },
     "node_modules/neo-async": {
       "version": "2.6.2",
@@ -4374,9 +4431,9 @@
       "license": "MIT"
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz",
-      "integrity": "sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
       "funding": [
         {
           "type": "github",
@@ -4482,34 +4539,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/postcss": {
-      "version": "8.4.49",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
-      "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.7",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
@@ -4552,24 +4581,24 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
-      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.0.tgz",
+      "integrity": "sha512-LtESOsMPTZgyYtwxhvdgdjGL0HmXEaRA/hVD6sol4zA60hVXXXP/SGmxnqDbgGE8gy7pYex7cym+5vYPcmaXBQ==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/codegen": "^2.0.5",
         "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/inquire": "^1.1.2",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
+        "long": "^5.3.2"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -4609,7 +4638,6 @@
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.32.0.tgz",
       "integrity": "sha512-GQWAHhxhxWBWA8oIBr1XahFVjQ9Fic6MK9ikijfd4TZHfE2+urfk+irVlR5VOn48uwMgM+loRRBJd6Yjsbc0zQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ramda"
@@ -4645,7 +4673,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4655,7 +4682,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -4887,7 +4913,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.80.0.tgz",
       "integrity": "sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -5068,12 +5093,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/shallowequal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
-      "license": "MIT"
     },
     "node_modules/short-unique-id": {
       "version": "5.3.2",
@@ -5256,15 +5275,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/source-map-js": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
-      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/sourcemap-codec": {
       "version": "1.4.8",
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
@@ -5392,9 +5402,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.2.tgz",
-      "integrity": "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
       "funding": [
         {
           "type": "github",
@@ -5404,21 +5414,15 @@
       "license": "MIT"
     },
     "node_modules/styled-components": {
-      "version": "6.3.9",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.3.9.tgz",
-      "integrity": "sha512-J72R4ltw0UBVUlEjTzI0gg2STOqlI9JBhQOL4Dxt7aJOnnSesy0qJDn4PYfMCafk9cWOaVg129Pesl5o+DIh0Q==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.4.1.tgz",
+      "integrity": "sha512-ADu2dF53esUzzM4I0ewxhxFtsDd6v4V6dNkg3vG0iFKhnt06sJneTZnRvujAosZwW0XD58IKgGMQoqri4wHRqg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emotion/is-prop-valid": "1.4.0",
-        "@emotion/unitless": "0.10.0",
-        "@types/stylis": "4.2.7",
         "css-to-react-native": "3.2.0",
         "csstype": "3.2.3",
-        "postcss": "8.4.49",
-        "shallowequal": "1.1.0",
-        "stylis": "4.3.6",
-        "tslib": "2.8.1"
+        "stylis": "4.3.6"
       },
       "engines": {
         "node": ">= 16"
@@ -5428,11 +5432,19 @@
         "url": "https://opencollective.com/styled-components"
       },
       "peerDependencies": {
+        "css-to-react-native": ">= 3.2.0",
         "react": ">= 16.8.0",
-        "react-dom": ">= 16.8.0"
+        "react-dom": ">= 16.8.0",
+        "react-native": ">= 0.68.0"
       },
       "peerDependenciesMeta": {
+        "css-to-react-native": {
+          "optional": true
+        },
         "react-dom": {
+          "optional": true
+        },
+        "react-native": {
           "optional": true
         }
       }
@@ -5897,6 +5909,21 @@
         }
       }
     },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -5907,9 +5934,9 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -5958,28 +5985,28 @@
       "name": "@jentic/openapi-bundler-redocly",
       "version": "0.1.0",
       "dependencies": {
-        "@redocly/cli": "=2.28.0"
+        "@redocly/cli": "=2.31.2"
       }
     },
     "packages/jentic-openapi-validator-redocly": {
       "name": "@jentic/openapi-validator-redocly",
       "version": "0.1.0",
       "dependencies": {
-        "@redocly/cli": "=2.28.0"
+        "@redocly/cli": "=2.31.2"
       }
     },
     "packages/jentic-openapi-validator-speclynx": {
       "name": "@jentic/openapi-validator-speclynx",
       "version": "0.1.0",
       "dependencies": {
-        "@speclynx/apidom-core": "4.9.0",
-        "@speclynx/apidom-datamodel": "4.9.0",
-        "@speclynx/apidom-json-path": "4.9.0",
-        "@speclynx/apidom-json-pointer": "4.9.0",
-        "@speclynx/apidom-ns-openapi-3-0": "4.9.0",
-        "@speclynx/apidom-ns-openapi-3-1": "4.9.0",
-        "@speclynx/apidom-reference": "4.9.0",
-        "@speclynx/apidom-traverse": "4.9.0",
+        "@speclynx/apidom-core": "4.10.0",
+        "@speclynx/apidom-datamodel": "4.10.0",
+        "@speclynx/apidom-json-path": "4.10.0",
+        "@speclynx/apidom-json-pointer": "4.10.0",
+        "@speclynx/apidom-ns-openapi-3-0": "4.10.0",
+        "@speclynx/apidom-ns-openapi-3-1": "4.10.0",
+        "@speclynx/apidom-reference": "4.10.0",
+        "@speclynx/apidom-traverse": "4.10.0",
         "commander": "^14.0.2",
         "vscode-languageserver-types": "^3.17.5"
       },
@@ -5991,7 +6018,7 @@
       "name": "@jentic/openapi-validator-spectral",
       "version": "0.1.0",
       "dependencies": {
-        "@stoplight/spectral-cli": "6.15.1"
+        "@stoplight/spectral-cli": "6.16.0"
       }
     }
   }

--- a/packages/jentic-openapi-transformer-redocly/README.md
+++ b/packages/jentic-openapi-transformer-redocly/README.md
@@ -26,7 +26,7 @@ pip install jentic-openapi-transformer-redocly
 The Redocly CLI will be automatically downloaded via npx on first use, or you can install it globally:
 
 ```bash
-npm install -g @redocly/cli@2.28.0
+npm install -g @redocly/cli@2.31.2
 ```
 
 ## Quick Start
@@ -126,7 +126,7 @@ uv run --package jentic-openapi-transformer-redocly pytest packages/jentic-opena
 class RedoclyBundlerBackend(BaseBundlerBackend):
     def __init__(
             self,
-            redocly_path: str = "npx --yes @redocly/cli@2.28.0",
+            redocly_path: str = "npx --yes @redocly/cli@2.31.2",
             timeout: float = 600.0,
             allowed_base_dir: str | Path | None = None,
     ) -> None

--- a/packages/jentic-openapi-transformer-redocly/package.json
+++ b/packages/jentic-openapi-transformer-redocly/package.json
@@ -4,6 +4,6 @@
   "description": "OpenAPI bundler using Redocly CLI for jentic-openapi-tools",
   "private": true,
   "dependencies": {
-    "@redocly/cli": "=2.28.0"
+    "@redocly/cli": "=2.31.2"
   }
 }

--- a/packages/jentic-openapi-transformer-redocly/src/jentic/apitools/openapi/transformer/bundler/backends/redocly/__init__.py
+++ b/packages/jentic-openapi-transformer-redocly/src/jentic/apitools/openapi/transformer/bundler/backends/redocly/__init__.py
@@ -18,7 +18,7 @@ __all__ = ["RedoclyBundlerBackend"]
 class RedoclyBundlerBackend(BaseBundlerBackend):
     def __init__(
         self,
-        redocly_path: str = "npx --yes @redocly/cli@2.28.0",
+        redocly_path: str = "npx --yes @redocly/cli@2.31.2",
         timeout: float = 600.0,
         allowed_base_dir: str | Path | None = None,
     ):
@@ -26,7 +26,7 @@ class RedoclyBundlerBackend(BaseBundlerBackend):
         Initialize the RedoclyBundler.
 
         Args:
-            redocly_path: Path to the redocly CLI executable (default: "npx --yes @redocly/cli@2.28.0").
+            redocly_path: Path to the redocly CLI executable (default: "npx --yes @redocly/cli@2.31.2").
                 Uses shell-safe parsing to handle quoted arguments properly.
             timeout: Maximum time in seconds to wait for Redocly CLI execution (default: 600.0)
             allowed_base_dir: Optional base directory for path security validation.

--- a/packages/jentic-openapi-transformer-redocly/tests/conftest.py
+++ b/packages/jentic-openapi-transformer-redocly/tests/conftest.py
@@ -79,7 +79,7 @@ def redocly_cli_available() -> bool:
     """Check if Redocly CLI is available on the system."""
     try:
         result = subprocess.run(
-            ["npx", "--yes", "@redocly/cli@2.28.0", "--version"], capture_output=True, timeout=10
+            ["npx", "--yes", "@redocly/cli@2.31.2", "--version"], capture_output=True, timeout=10
         )
         return result.returncode == 0
     except (subprocess.TimeoutExpired, FileNotFoundError):
@@ -98,7 +98,7 @@ def pytest_runtest_setup(item):
     if item.get_closest_marker("requires_redocly_cli"):
         try:
             result = subprocess.run(
-                ["npx", "--yes", "@redocly/cli@2.28.0", "--version"],
+                ["npx", "--yes", "@redocly/cli@2.31.2", "--version"],
                 capture_output=True,
                 timeout=10,
             )

--- a/packages/jentic-openapi-transformer-redocly/tests/test_redocly_bundle.py
+++ b/packages/jentic-openapi-transformer-redocly/tests/test_redocly_bundle.py
@@ -76,7 +76,7 @@ class TestRedoclyBundlerUnit:
     def test_init_with_defaults(self):
         """Test RedoclyBundlerBackend initialization with default values."""
         bundler = RedoclyBundlerBackend()
-        assert bundler.redocly_path == "npx --yes @redocly/cli@2.28.0"
+        assert bundler.redocly_path == "npx --yes @redocly/cli@2.31.2"
         assert bundler.timeout == 600.0
 
     def test_init_with_custom_path(self, redocly_bundler_with_custom_path: RedoclyBundlerBackend):

--- a/packages/jentic-openapi-transformer/tests/conftest.py
+++ b/packages/jentic-openapi-transformer/tests/conftest.py
@@ -208,7 +208,7 @@ def redocly_cli_available() -> bool:
     """Check if Redocly CLI is available on the system."""
     try:
         result = subprocess.run(
-            ["npx", "--yes", "@redocly/cli@2.28.0", "--version"], capture_output=True, timeout=10
+            ["npx", "--yes", "@redocly/cli@2.31.2", "--version"], capture_output=True, timeout=10
         )
         return result.returncode == 0
     except (subprocess.TimeoutExpired, FileNotFoundError):
@@ -227,7 +227,7 @@ def pytest_runtest_setup(item):
     if item.get_closest_marker("requires_redocly_cli"):
         try:
             result = subprocess.run(
-                ["npx", "--yes", "@redocly/cli@2.28.0", "--version"],
+                ["npx", "--yes", "@redocly/cli@2.31.2", "--version"],
                 capture_output=True,
                 timeout=10,
             )

--- a/packages/jentic-openapi-validator-redocly/README.md
+++ b/packages/jentic-openapi-validator-redocly/README.md
@@ -26,7 +26,7 @@ pip install jentic-openapi-validator-redocly
 The Redocly CLI will be automatically downloaded via npx on first use, or you can install it globally:
 
 ```bash
-npm install -g @redocly/cli@2.28.0
+npm install -g @redocly/cli@2.31.2
 ```
 
 ## Quick Start
@@ -72,7 +72,7 @@ print(f"Document is valid: {result.valid}")
 validator = RedoclyValidatorBackend(redocly_path="/usr/local/bin/redocly")
 
 # Use specific version via npx
-validator = RedoclyValidatorBackend(redocly_path="npx --yes @redocly/cli@2.28.0")
+validator = RedoclyValidatorBackend(redocly_path="npx --yes @redocly/cli@2.31.2")
 ```
 
 ### Custom Rulesets
@@ -243,7 +243,7 @@ uv run --package jentic-openapi-validator-redocly pytest packages/jentic-openapi
 class RedoclyValidatorBackend(BaseValidatorBackend):
     def __init__(
             self,
-            redocly_path: str = "npx --yes @redocly/cli@2.28.0",
+            redocly_path: str = "npx --yes @redocly/cli@2.31.2",
             ruleset_path: str | None = None,
             timeout: float = 600.0,
             allowed_base_dir: str | Path | None = None,

--- a/packages/jentic-openapi-validator-redocly/package.json
+++ b/packages/jentic-openapi-validator-redocly/package.json
@@ -4,6 +4,6 @@
   "description": "OpenAPI validator using Redocly for jentic-openapi-tools",
   "private": true,
   "dependencies": {
-    "@redocly/cli": "=2.28.0"
+    "@redocly/cli": "=2.31.2"
   }
 }

--- a/packages/jentic-openapi-validator-redocly/src/jentic/apitools/openapi/validator/backends/redocly/__init__.py
+++ b/packages/jentic-openapi-validator-redocly/src/jentic/apitools/openapi/validator/backends/redocly/__init__.py
@@ -34,7 +34,7 @@ ruleset_file = rulesets_files_dir.joinpath("redocly.yaml")
 class RedoclyValidatorBackend(BaseValidatorBackend):
     def __init__(
         self,
-        redocly_path: str = "npx --yes @redocly/cli@2.28.0",
+        redocly_path: str = "npx --yes @redocly/cli@2.31.2",
         ruleset_path: str | None = None,
         timeout: float = 600.0,
         allowed_base_dir: str | Path | None = None,
@@ -44,7 +44,7 @@ class RedoclyValidatorBackend(BaseValidatorBackend):
         Initialize the RedoclyValidatorBackend.
 
         Args:
-            redocly_path: Path to the redocly CLI executable (default: "npx --yes @redocly/cli@2.28.0").
+            redocly_path: Path to the redocly CLI executable (default: "npx --yes @redocly/cli@2.31.2").
                 Uses shell-safe parsing to handle quoted arguments properly.
             ruleset_path: Path to a custom ruleset file. If None, uses bundled default ruleset.
             timeout: Maximum time in seconds to wait for Redocly CLI execution (default: 600.0)

--- a/packages/jentic-openapi-validator-redocly/tests/conftest.py
+++ b/packages/jentic-openapi-validator-redocly/tests/conftest.py
@@ -86,7 +86,7 @@ def pytest_runtest_setup(item):
     if item.get_closest_marker("requires_redocly_cli"):
         try:
             result = run_subprocess(
-                ["npx", "--yes", "@redocly/cli@2.28.0", "--version"],
+                ["npx", "--yes", "@redocly/cli@2.31.2", "--version"],
                 timeout=10.0,
             )
             if result.returncode != 0:

--- a/packages/jentic-openapi-validator-redocly/tests/test_redocly_validate.py
+++ b/packages/jentic-openapi-validator-redocly/tests/test_redocly_validate.py
@@ -85,7 +85,7 @@ class TestRedoclyValidatorUnit:
     def test_initialization_with_defaults(self):
         """Test RedoclyValidator initialization with default values."""
         validator = RedoclyValidatorBackend()
-        assert validator.redocly_path == "npx --yes @redocly/cli@2.28.0"
+        assert validator.redocly_path == "npx --yes @redocly/cli@2.31.2"
         assert validator.ruleset_path is None
         assert validator.timeout == 600.0
 
@@ -103,7 +103,7 @@ class TestRedoclyValidatorUnit:
         """Test RedoclyValidator with custom timeout."""
         validator = RedoclyValidatorBackend(timeout=60.0)
         assert validator.timeout == 60.0
-        assert validator.redocly_path == "npx --yes @redocly/cli@2.28.0"  # default
+        assert validator.redocly_path == "npx --yes @redocly/cli@2.31.2"  # default
         assert validator.ruleset_path is None  # default
 
     def test_initialization_with_all_custom_parameters(self, custom_ruleset_path):

--- a/packages/jentic-openapi-validator-speclynx/src/jentic/apitools/openapi/validator/backends/speclynx/resources/package.json
+++ b/packages/jentic-openapi-validator-speclynx/src/jentic/apitools/openapi/validator/backends/speclynx/resources/package.json
@@ -14,13 +14,13 @@
   "dependencies": {
     "commander": "^14.0.2",
     "vscode-languageserver-types": "^3.17.5",
-    "@speclynx/apidom-core": "4.9.0",
-    "@speclynx/apidom-datamodel": "4.9.0",
-    "@speclynx/apidom-json-path": "4.9.0",
-    "@speclynx/apidom-json-pointer": "4.9.0",
-    "@speclynx/apidom-ns-openapi-3-0": "4.9.0",
-    "@speclynx/apidom-ns-openapi-3-1": "4.9.0",
-    "@speclynx/apidom-reference": "4.9.0",
-    "@speclynx/apidom-traverse": "4.9.0"
+    "@speclynx/apidom-core": "4.10.0",
+    "@speclynx/apidom-datamodel": "4.10.0",
+    "@speclynx/apidom-json-path": "4.10.0",
+    "@speclynx/apidom-json-pointer": "4.10.0",
+    "@speclynx/apidom-ns-openapi-3-0": "4.10.0",
+    "@speclynx/apidom-ns-openapi-3-1": "4.10.0",
+    "@speclynx/apidom-reference": "4.10.0",
+    "@speclynx/apidom-traverse": "4.10.0"
   }
 }

--- a/packages/jentic-openapi-validator-spectral/README.md
+++ b/packages/jentic-openapi-validator-spectral/README.md
@@ -72,7 +72,7 @@ print(f"Document is valid: {result.valid}")
 validator = SpectralValidatorBackend(spectral_path="/usr/local/bin/spectral")
 
 # Use specific version via npx
-validator = SpectralValidatorBackend(spectral_path="npx --yes @stoplight/spectral-cli@6.15.1")
+validator = SpectralValidatorBackend(spectral_path="npx --yes @stoplight/spectral-cli@6.16.0")
 ```
 
 ### Custom Rulesets
@@ -247,7 +247,7 @@ uv run --package jentic-openapi-validator-spectral pytest packages/jentic-openap
 class SpectralValidatorBackend(BaseValidatorBackend):
     def __init__(
             self,
-            spectral_path: str = "npx --yes @stoplight/spectral-cli@6.15.1",
+            spectral_path: str = "npx --yes @stoplight/spectral-cli@6.16.0",
             ruleset_path: str | None = None,
             timeout: float = 600.0,
             allowed_base_dir: str | Path | None = None,

--- a/packages/jentic-openapi-validator-spectral/package.json
+++ b/packages/jentic-openapi-validator-spectral/package.json
@@ -4,6 +4,6 @@
   "description": "OpenAPI validator using Spectral for jentic-openapi-tools",
   "private": true,
   "dependencies": {
-    "@stoplight/spectral-cli": "6.15.1"
+    "@stoplight/spectral-cli": "6.16.0"
   }
 }

--- a/packages/jentic-openapi-validator-spectral/src/jentic/apitools/openapi/validator/backends/spectral/__init__.py
+++ b/packages/jentic-openapi-validator-spectral/src/jentic/apitools/openapi/validator/backends/spectral/__init__.py
@@ -32,7 +32,7 @@ ruleset_file = rulesets_files_dir.joinpath("spectral.mjs")
 class SpectralValidatorBackend(BaseValidatorBackend):
     def __init__(
         self,
-        spectral_path: str = "npx --yes @stoplight/spectral-cli@6.15.1",
+        spectral_path: str = "npx --yes @stoplight/spectral-cli@6.16.0",
         ruleset_path: str | None = None,
         timeout: float = 600.0,
         allowed_base_dir: str | Path | None = None,
@@ -41,7 +41,7 @@ class SpectralValidatorBackend(BaseValidatorBackend):
         Initialize the SpectralValidatorBackend.
 
         Args:
-            spectral_path: Path to the spectral CLI executable (default: "npx --yes @stoplight/spectral-cli@6.15.1").
+            spectral_path: Path to the spectral CLI executable (default: "npx --yes @stoplight/spectral-cli@6.16.0").
                 Uses shell-safe parsing to handle quoted arguments properly.
             ruleset_path: Path to a custom ruleset file. If None, uses bundled default ruleset.
             timeout: Maximum time in seconds to wait for Spectral CLI execution (default: 600.0)

--- a/packages/jentic-openapi-validator-spectral/tests/conftest.py
+++ b/packages/jentic-openapi-validator-spectral/tests/conftest.py
@@ -80,7 +80,7 @@ def pytest_runtest_setup(item):
     if item.get_closest_marker("requires_spectral_cli"):
         try:
             result = run_subprocess(
-                ["npx", "--yes", "@stoplight/spectral-cli@6.15.1", "--version"],
+                ["npx", "--yes", "@stoplight/spectral-cli@6.16.0", "--version"],
                 timeout=10.0,
             )
             if result.returncode != 0:

--- a/packages/jentic-openapi-validator-spectral/tests/test_spectral_validate.py
+++ b/packages/jentic-openapi-validator-spectral/tests/test_spectral_validate.py
@@ -72,7 +72,7 @@ class TestSpectralValidatorUnit:
     def test_initialization_with_defaults(self):
         """Test SpectralValidator initialization with default values."""
         validator = SpectralValidatorBackend()
-        assert validator.spectral_path == "npx --yes @stoplight/spectral-cli@6.15.1"
+        assert validator.spectral_path == "npx --yes @stoplight/spectral-cli@6.16.0"
         assert validator.ruleset_path is None
         assert validator.timeout == 600.0
 
@@ -90,7 +90,7 @@ class TestSpectralValidatorUnit:
         """Test SpectralValidator with custom timeout."""
         validator = SpectralValidatorBackend(timeout=60.0)
         assert validator.timeout == 60.0
-        assert validator.spectral_path == "npx --yes @stoplight/spectral-cli@6.15.1"  # default
+        assert validator.spectral_path == "npx --yes @stoplight/spectral-cli@6.16.0"  # default
         assert validator.ruleset_path is None  # default
 
     def test_initialization_with_all_custom_parameters(self, custom_ruleset_path):

--- a/packages/jentic-openapi-validator/tests/conftest.py
+++ b/packages/jentic-openapi-validator/tests/conftest.py
@@ -164,7 +164,7 @@ def spectral_cli_available() -> bool:
     """Check if Spectral CLI is available on the system."""
     try:
         result = subprocess.run(
-            ["npx", "--yes", "@stoplight/spectral-cli@6.15.1", "--version"],
+            ["npx", "--yes", "@stoplight/spectral-cli@6.16.0", "--version"],
             capture_output=True,
             timeout=10,
         )
@@ -188,7 +188,7 @@ def pytest_runtest_setup(item):
     if item.get_closest_marker("requires_spectral_cli"):
         try:
             result = subprocess.run(
-                ["npx", "--yes", "@stoplight/spectral-cli@6.15.1", "--version"],
+                ["npx", "--yes", "@stoplight/spectral-cli@6.16.0", "--version"],
                 capture_output=True,
                 timeout=10,
             )
@@ -200,7 +200,7 @@ def pytest_runtest_setup(item):
     if item.get_closest_marker("requires_redocly_cli"):
         try:
             result = subprocess.run(
-                ["npx", "--yes", "@redocly/cli@2.28.0", "--version"],
+                ["npx", "--yes", "@redocly/cli@2.31.2", "--version"],
                 capture_output=True,
                 timeout=10,
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,12 +29,12 @@ Homepage = "https://github.com/jentic/jentic-openapi-tools"
 # Development-only dependencies (will not be published)
 [dependency-groups]
 dev = [
-  "pre-commit>=4.3,<4.6",
+  "pre-commit>=4.3,<4.7",
   "ruff>=0.14.1,<0.16.0",
-  "pyright~=1.1.407",
+  "pyright~=1.1.409",
   "pytest>=8.4.2,<9.1.0",
   "python-semantic-release>=10.4.1,<10.6.0",
-  "poethepoet>=0.37,<0.45",
+  "poethepoet>=0.37,<0.46",
 ]
 
 [tool.poe.tasks]

--- a/uv.lock
+++ b/uv.lock
@@ -225,14 +225,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.45"
+version = "3.1.50"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9a/c8/dd58967d119baab745caec2f9d853297cec1989ec1d63f677d3880632b88/gitpython-3.1.45.tar.gz", hash = "sha256:85b0ee964ceddf211c41b9f27a49086010a190fd8132a24e21f362a4b36a791c", size = 215076, upload-time = "2025-07-24T03:45:54.871Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/f6/354ae6491228b5eb40e10d89c4d13c651fe1cf7556e35ebdded50cff57ce/gitpython-3.1.50.tar.gz", hash = "sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc", size = 219798, upload-time = "2026-05-06T04:01:26.571Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/61/d4b89fec821f72385526e1b9d9a3a0385dda4a72b206d28049e2c7cd39b8/gitpython-3.1.45-py3-none-any.whl", hash = "sha256:8908cb2e02fb3b93b7eb0f2827125cb699869470432cc885f019b8fd0fccff77", size = 208168, upload-time = "2025-07-24T03:45:52.517Z" },
+    { url = "https://files.pythonhosted.org/packages/20/7a/1c6e3562dfd8950adbb11ffbc65d21e7c89d01a6e4f137fa981056de25c5/gitpython-3.1.50-py3-none-any.whl", hash = "sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9", size = 212507, upload-time = "2026-05-06T04:01:23.799Z" },
 ]
 
 [[package]]
@@ -361,9 +361,9 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "poethepoet", specifier = ">=0.37,<0.45" },
-    { name = "pre-commit", specifier = ">=4.3,<4.6" },
-    { name = "pyright", specifier = "~=1.1.407" },
+    { name = "poethepoet", specifier = ">=0.37,<0.46" },
+    { name = "pre-commit", specifier = ">=4.3,<4.7" },
+    { name = "pyright", specifier = "~=1.1.409" },
     { name = "pytest", specifier = ">=8.4.2,<9.1.0" },
     { name = "python-semantic-release", specifier = ">=10.4.1,<10.6.0" },
     { name = "ruff", specifier = ">=0.14.1,<0.16.0" },
@@ -807,20 +807,20 @@ wheels = [
 
 [[package]]
 name = "poethepoet"
-version = "0.44.0"
+version = "0.45.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pastel" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a1/a4/e487662f12a5ecd2ac4d77f7697e4bda481953bb80032b158e5ab55173d4/poethepoet-0.44.0.tar.gz", hash = "sha256:c2667b513621788fb46482e371cdf81c0b04344e0e0bcb7aa8af45f84c2fce7b", size = 96040, upload-time = "2026-04-06T19:40:58.908Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/28/d54e16913f591f01b2e1c4ab526ccbba47864d9bf10299904c823a760d25/poethepoet-0.45.0.tar.gz", hash = "sha256:cf2c2df4c185d33b619c2771de2b28c2b81c733f072226030c7fa4c273c040f8", size = 97150, upload-time = "2026-04-28T21:04:59.301Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/80/b7/503b7d3a51b0de9a329f1323048d166e309a97bb31bdc60e6acd11d2c71f/poethepoet-0.44.0-py3-none-any.whl", hash = "sha256:36d3d834708ed069ac1e4f8ed77915c55265b7b6e01aeb2fe617c9fe9cfd524a", size = 122873, upload-time = "2026-04-06T19:40:57.369Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/99/4aefb693b0f52783fab496492f4444a75137312c386eb7c3320f1b0a1602/poethepoet-0.45.0-py3-none-any.whl", hash = "sha256:8e25f6e834ecf25fe2ddca676a4e0207eeb2e19def0a8709fc5c7f18e86cd68c", size = 123920, upload-time = "2026-04-28T21:04:57.66Z" },
 ]
 
 [[package]]
 name = "pre-commit"
-version = "4.5.1"
+version = "4.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cfgv" },
@@ -829,9 +829,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "virtualenv" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/40/f1/6d86a29246dfd2e9b6237f0b5823717f60cad94d47ddc26afa916d21f525/pre_commit-4.5.1.tar.gz", hash = "sha256:eb545fcff725875197837263e977ea257a402056661f09dae08e4b149b030a61", size = 198232, upload-time = "2025-12-16T21:14:33.552Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/22/2de9408ac81acbb8a7d05d4cc064a152ccf33b3d480ebe0cd292153db239/pre_commit-4.6.0.tar.gz", hash = "sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9", size = 198525, upload-time = "2026-04-21T20:31:41.613Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/19/fd3ef348460c80af7bb4669ea7926651d1f95c23ff2df18b9d24bab4f3fa/pre_commit-4.5.1-py2.py3-none-any.whl", hash = "sha256:3b3afd891e97337708c1674210f8eba659b52a38ea5f822ff142d10786221f77", size = 226437, upload-time = "2025-12-16T21:14:32.409Z" },
+    { url = "https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl", hash = "sha256:e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b", size = 226472, upload-time = "2026-04-21T20:31:40.092Z" },
 ]
 
 [[package]]
@@ -953,15 +953,15 @@ wheels = [
 
 [[package]]
 name = "pyright"
-version = "1.1.408"
+version = "1.1.409"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nodeenv" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/74/b2/5db700e52554b8f025faa9c3c624c59f1f6c8841ba81ab97641b54322f16/pyright-1.1.408.tar.gz", hash = "sha256:f28f2321f96852fa50b5829ea492f6adb0e6954568d1caa3f3af3a5f555eb684", size = 4400578, upload-time = "2026-01-08T08:07:38.795Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/4e/3aa27f74211522dba7e9cbc3e74de779c6d4b654c54e50a4840623be8014/pyright-1.1.409.tar.gz", hash = "sha256:986ee05beca9e077c165758ad123667c679e050059a2546aa02473930394bc93", size = 4430434, upload-time = "2026-04-23T11:02:03.799Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/82/a2c93e32800940d9573fb28c346772a14778b84ba7524e691b324620ab89/pyright-1.1.408-py3-none-any.whl", hash = "sha256:090b32865f4fdb1e0e6cd82bf5618480d48eecd2eb2e70f960982a3d9a4c17c1", size = 6399144, upload-time = "2026-01-08T08:07:37.082Z" },
+    { url = "https://files.pythonhosted.org/packages/16/6b/330d8ebae582b30c2959a1ef4c3bc344ebde48c2ff0c3f113c4710735e11/pyright-1.1.409-py3-none-any.whl", hash = "sha256:aa3ea228cab90c845c7a60d28db7a844c04315356392aa09fafcee98c8c22fb3", size = 6438161, upload-time = "2026-04-23T11:02:01.309Z" },
 ]
 
 [[package]]
@@ -1304,27 +1304,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.11"
+version = "0.15.13"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e4/8d/192f3d7103816158dfd5ea50d098ef2aec19194e6cbccd4b3485bdb2eb2d/ruff-0.15.11.tar.gz", hash = "sha256:f092b21708bf0e7437ce9ada249dfe688ff9a0954fc94abab05dcea7dcd29c33", size = 4637264, upload-time = "2026-04-16T18:46:26.58Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/21/a7d5c126d5b557715ef81098f3db2fe20f622a039ff2e626af28d674ab80/ruff-0.15.13.tar.gz", hash = "sha256:f9d89f17f7ba7fb2ed42921f0df75da797a9a5d71bc39049e2c687cf2baf44b7", size = 4678180, upload-time = "2026-05-14T13:44:37.869Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/1e/6aca3427f751295ab011828e15e9bf452200ac74484f1db4be0197b8170b/ruff-0.15.11-py3-none-linux_armv6l.whl", hash = "sha256:e927cfff503135c558eb581a0c9792264aae9507904eb27809cdcff2f2c847b7", size = 10607943, upload-time = "2026-04-16T18:46:05.967Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/26/1341c262e74f36d4e84f3d6f4df0ac68cd53331a66bfc5080daa17c84c0b/ruff-0.15.11-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:7a1b5b2938d8f890b76084d4fa843604d787a912541eae85fd7e233398bbb73e", size = 10988592, upload-time = "2026-04-16T18:46:00.742Z" },
-    { url = "https://files.pythonhosted.org/packages/03/71/850b1d6ffa9564fbb6740429bad53df1094082fe515c8c1e74b6d8d05f18/ruff-0.15.11-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d4176f3d194afbdaee6e41b9ccb1a2c287dba8700047df474abfbe773825d1cb", size = 10338501, upload-time = "2026-04-16T18:46:03.723Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/11/cc1284d3e298c45a817a6aadb6c3e1d70b45c9b36d8d9cce3387b495a03a/ruff-0.15.11-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3b17c886fb88203ced3afe7f14e8d5ae96e9d2f4ccc0ee66aa19f2c2675a27e4", size = 10670693, upload-time = "2026-04-16T18:46:41.941Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/9e/f8288b034ab72b371513c13f9a41d9ba3effac54e24bfb467b007daee2ca/ruff-0.15.11-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:49fafa220220afe7758a487b048de4c8f9f767f37dfefad46b9dd06759d003eb", size = 10416177, upload-time = "2026-04-16T18:46:21.717Z" },
-    { url = "https://files.pythonhosted.org/packages/85/71/504d79abfd3d92532ba6bbe3d1c19fada03e494332a59e37c7c2dabae427/ruff-0.15.11-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f2ab8427e74a00d93b8bda1307b1e60970d40f304af38bccb218e056c220120d", size = 11221886, upload-time = "2026-04-16T18:46:15.086Z" },
-    { url = "https://files.pythonhosted.org/packages/43/5a/947e6ab7a5ad603d65b474be15a4cbc6d29832db5d762cd142e4e3a74164/ruff-0.15.11-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:195072c0c8e1fc8f940652073df082e37a5d9cb43b4ab1e4d0566ab8977a13b7", size = 12075183, upload-time = "2026-04-16T18:46:07.944Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/a1/0b7bb6268775fdd3a0818aee8efd8f5b4e231d24dd4d528ced2534023182/ruff-0.15.11-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a3a0996d486af3920dec930a2e7daed4847dfc12649b537a9335585ada163e9e", size = 11516575, upload-time = "2026-04-16T18:46:31.687Z" },
-    { url = "https://files.pythonhosted.org/packages/30/c3/bb5168fc4d233cc06e95f482770d0f3c87945a0cd9f614b90ea8dc2f2833/ruff-0.15.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1bef2cb556d509259f1fe440bb9cd33c756222cf0a7afe90d15edf0866702431", size = 11306537, upload-time = "2026-04-16T18:46:36.988Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/92/4cfae6441f3967317946f3b788136eecf093729b94d6561f963ed810c82e/ruff-0.15.11-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:030d921a836d7d4a12cf6e8d984a88b66094ccb0e0f17ddd55067c331191bf19", size = 11296813, upload-time = "2026-04-16T18:46:24.182Z" },
-    { url = "https://files.pythonhosted.org/packages/43/26/972784c5dde8313acde8ac71ba8ac65475b85db4a2352a76c9934361f9bc/ruff-0.15.11-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:0e783b599b4577788dbbb66b9addcef87e9a8832f4ce0c19e34bf55543a2f890", size = 10633136, upload-time = "2026-04-16T18:46:39.802Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/53/3985a4f185020c2f367f2e08a103032e12564829742a1b417980ce1514a0/ruff-0.15.11-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:ae90592246625ba4a34349d68ec28d4400d75182b71baa196ddb9f82db025ef5", size = 10424701, upload-time = "2026-04-16T18:46:10.381Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/57/bf0dfb32241b56c83bb663a826133da4bf17f682ba8c096973065f6e6a68/ruff-0.15.11-py3-none-musllinux_1_2_i686.whl", hash = "sha256:1f111d62e3c983ed20e0ca2e800f8d77433a5b1161947df99a5c2a3fb60514f0", size = 10873887, upload-time = "2026-04-16T18:46:29.157Z" },
-    { url = "https://files.pythonhosted.org/packages/02/05/e48076b2a57dc33ee8c7a957296f97c744ca891a8ffb4ffb1aaa3b3f517d/ruff-0.15.11-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:06f483d6646f59eaffba9ae30956370d3a886625f511a3108994000480621d1c", size = 11404316, upload-time = "2026-04-16T18:46:19.462Z" },
-    { url = "https://files.pythonhosted.org/packages/88/27/0195d15fe7a897cbcba0904792c4b7c9fdd958456c3a17d2ea6093716a9a/ruff-0.15.11-py3-none-win32.whl", hash = "sha256:476a2aa56b7da0b73a3ee80b6b2f0e19cce544245479adde7baa65466664d5f3", size = 10655535, upload-time = "2026-04-16T18:46:12.47Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/5e/c927b325bd4c1d3620211a4b96f47864633199feed60fa936025ab27e090/ruff-0.15.11-py3-none-win_amd64.whl", hash = "sha256:8b6756d88d7e234fb0c98c91511aae3cd519d5e3ed271cae31b20f39cb2a12a3", size = 11779692, upload-time = "2026-04-16T18:46:17.268Z" },
-    { url = "https://files.pythonhosted.org/packages/63/b6/aeadee5443e49baa2facd51131159fd6301cc4ccfc1541e4df7b021c37dd/ruff-0.15.11-py3-none-win_arm64.whl", hash = "sha256:063fed18cc1bbe0ee7393957284a6fe8b588c6a406a285af3ee3f46da2391ee4", size = 11032614, upload-time = "2026-04-16T18:46:34.487Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/61/11d458dc6ac22504fd8e237b29dfd40504c7fbbcc8930402cfe51a8e63ed/ruff-0.15.13-py3-none-linux_armv6l.whl", hash = "sha256:444b580fc72fd6887e650acd3e575e18cdc79dbcf42fb4030b491057921f61f8", size = 10738279, upload-time = "2026-05-14T13:44:18.7Z" },
+    { url = "https://files.pythonhosted.org/packages/86/ca/caa871ee7be718c45256fada4e16a218ee3e33f0c4a46b729a60a24912e6/ruff-0.15.13-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:6590d009e7cb7ebf36f83dbdd44a3fa48a0994ff6f1cdc1b08006abe58f98dc7", size = 11124798, upload-time = "2026-05-14T13:44:06.427Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/19/43f5f2e568dddde567fc41f8471f9432c09563e19d3e617a48cfa52f8f0a/ruff-0.15.13-py3-none-macosx_11_0_arm64.whl", hash = "sha256:1c26d2f66163deeb6e08d8b39fbbe983ce3c71cea06a6d7591cfd1421793c629", size = 10460761, upload-time = "2026-05-14T13:44:04.375Z" },
+    { url = "https://files.pythonhosted.org/packages/99/df/cf938cd6de3003178f03ad7c1ea2a6c099468c03a35037985070b37e76be/ruff-0.15.13-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9dbd6f94b434f896308e4d57fb7bfde0d02b99f7a64b3bdab0fdfa6a864203a5", size = 10804451, upload-time = "2026-05-14T13:44:25.221Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/7d/5d0973129b154ded2225729169d7068f26b467760b146493fde138415f23/ruff-0.15.13-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bf3259f3be4d181bda591da5db2571aed6853c6a048157756448020bc6c5cd22", size = 10534285, upload-time = "2026-05-14T13:44:08.888Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/e3/6b999bbc66cd51e5f073842bc2a3995e99c5e0e72e16b15e7261f7abf57a/ruff-0.15.13-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ae9c17e5eb4430c154e76abc25d79a318190f5a997f38fb6b114416c5319ffc9", size = 11312063, upload-time = "2026-05-14T13:44:11.274Z" },
+    { url = "https://files.pythonhosted.org/packages/af/5a/642639e9f5db04f1e97fbd6e091c6fd20725bdf072fb114d00eefb9e6eb8/ruff-0.15.13-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2e2e39bff6c341f4b577a21b801326fab0b11847f48fcaa83f00a113c9b3cb55", size = 12183079, upload-time = "2026-05-14T13:44:01.634Z" },
+    { url = "https://files.pythonhosted.org/packages/19/4c/7585735f6b53b0f12de13618b2f7d250a844f018822efc899df2e7b8295f/ruff-0.15.13-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e8d9a8e08013542e94d3220bc5b62cc3e5ef87c5f74bff367d3fac14fab013e6", size = 11440833, upload-time = "2026-05-14T13:43:59.043Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/31/bf1a0803d077e679cfeee5f2f67290a0fa79c7385b5d9a8c17b9db2c48f0/ruff-0.15.13-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cc411dfebe5eebe55ce041c6ae080eb7668955e866daa2fbb16692a784f1c4ca", size = 11434486, upload-time = "2026-05-14T13:44:27.761Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/4e/62c9b999875d4f14db80f277c030578f5e249c9852d65b7ac7ad0b43c041/ruff-0.15.13-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:768494eb08b9cee54e2fd27969966f74db5a57f6eaa7a90fcb3306af34dfc4bd", size = 11385189, upload-time = "2026-05-14T13:44:13.704Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/89/7e959047a104df3eb12863447c110140191fc5b6c4f379ea2e803fcdb0e4/ruff-0.15.13-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:fb75f9a3a7e42ffe117d734494e6c5e5cb3565d66e12612cb63d0e572a41a5b6", size = 10781380, upload-time = "2026-05-14T13:43:56.734Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/52/5fd18f3b88cab63e88aa11516b3b4e1e5f720e5c330f8dbe5c26210f41f8/ruff-0.15.13-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8cb74dd33bb2f6613faf7fc03b660053b5ac4f80e706d5788c6335e2a8048d51", size = 10540605, upload-time = "2026-05-14T13:44:20.748Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e0/9e35f338990d3e41a82875ff7053ffe97541dae81c9d02143177f381d572/ruff-0.15.13-py3-none-musllinux_1_2_i686.whl", hash = "sha256:7ef823f817fcd191dc934e984be9cf4094f808effa16f2542ad8e821ba02bbf2", size = 11036554, upload-time = "2026-05-14T13:44:16.256Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/13/070fb048c24080fba188f66371e2a92785be257ad02242066dc7255ac6e9/ruff-0.15.13-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:f345a13937bd7f09f6f5d19fa0721b0c103e00e7f62bc67089a8e5e037719e0b", size = 11528133, upload-time = "2026-05-14T13:44:22.808Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/8c/b1e1666aef7fc6555094d73ae6cd981701781ae85b97ceefc0eebd0b4668/ruff-0.15.13-py3-none-win32.whl", hash = "sha256:4044f94208b3b05ba0fc4a4abd0558cf4d6459bd18325eead7fd8cc66f909b41", size = 10721455, upload-time = "2026-05-14T13:44:35.697Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/a6/870a3e8a50590bb92be184ad928c2922f088b00d9dc5c5ec7b924ee08c22/ruff-0.15.13-py3-none-win_amd64.whl", hash = "sha256:7064884d442b7d477b4e7473d12da7f08851d2b1982763c5d3f388a19468a1a4", size = 11900409, upload-time = "2026-05-14T13:44:30.389Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/36/9c015cd052fca743dae8cb2aeb16b551444787467db42ceab0fc968865af/ruff-0.15.13-py3-none-win_arm64.whl", hash = "sha256:2471da9bd1068c8c064b5fd9c0c4b6dddffd6369cb1cd68b29993b1709ff1b21", size = 11179336, upload-time = "2026-05-14T13:44:33.026Z" },
 ]
 
 [[package]]
@@ -1386,11 +1386,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **@redocly/cli** 2.28.0 → 2.31.2 — updated package.json, npx defaults in Python source, tests, and READMEs
- **@stoplight/spectral-cli** 6.15.1 → 6.16.0 — updated package.json, npx defaults in Python source, tests, and READMEs
- **@speclynx/apidom-*** 4.9.0 → 4.10.0 — all 8 packages, both workspace and resources package.json, repacked tgz
- **JS transitive** (package-lock.json only): protobufjs 7.6.0, @protobufjs/utf8 1.1.1, axios 1.16.1, fast-uri 3.1.2, fast-xml-builder 1.2.0, fast-xml-parser 5.8.0
- **Python dev** (pyproject.toml + uv.lock): pyright 1.1.409, poethepoet 0.45.0, pre-commit 4.6.0, ruff 0.15.13
- **Python transitive** (uv.lock only): urllib3 2.7.0, gitpython 3.1.50

Skipped: postcss (removed upstream by redocly update — already gone after @redocly/cli bump).

## Test plan

- [x] All 1868 tests pass (`uv run poe test`)
- [x] All pre-commit hooks pass (ruff, pyright, conventional commit, uv-lock)
- [x] No stale version strings remain for redocly, spectral, or apidom

🤖 Generated with [Claude Code](https://claude.com/claude-code)