### PR TITLE
feat(validator-speclynx): integrate apidom 4.11.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62,9 +62,9 @@
       }
     },
     "node_modules/@babel/runtime-corejs3": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.29.0.tgz",
-      "integrity": "sha512-TgUkdp71C9pIbBcHudc+gXZnihEDOjUAmXO1VO4HHGES7QLZcShR0stfKIxLSNIYx2fqhmJChOjm/wkF8wv4gA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.29.7.tgz",
+      "integrity": "sha512-ppj9ouYku+RX0ljtgZd+KMO5mkM2bCqg8H2PYAFWnLsHEIKIdRojqbJ2i3eVHrisuxy7nOFCmngTDdWtUCdXUQ==",
       "license": "MIT",
       "dependencies": {
         "core-js-pure": "^3.48.0"
@@ -229,6 +229,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -774,514 +775,514 @@
       }
     },
     "node_modules/@speclynx/apidom-core": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-core/-/apidom-core-4.10.0.tgz",
-      "integrity": "sha512-sSTwLMTaJR3m09OntcJCk/vnTSei2qgr5Xj4qb8lScdLI1kQaEMJfn6iWKdVs365gkM63U+Lds1nQahA1lVhCA==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-core/-/apidom-core-4.11.1.tgz",
+      "integrity": "sha512-l+wQbLVHuC40rOgI5aG1Z2oACDq5coO/6H8TvuRb6/Tek/8SlDdBiiJYPrw+ALF9/FO8uQaEa5y55fRD1w/4xw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-datamodel": "4.10.0",
-        "@speclynx/apidom-error": "4.10.0",
-        "@speclynx/apidom-traverse": "4.10.0",
+        "@babel/runtime-corejs3": "^7.29.7",
+        "@speclynx/apidom-datamodel": "4.11.1",
+        "@speclynx/apidom-error": "4.11.1",
+        "@speclynx/apidom-traverse": "4.11.1",
         "ramda": "~0.32.0",
-        "ramda-adjunct": "^6.0.0",
+        "ramda-adjunct": "^6.1.0",
         "short-unique-id": "^5.3.2",
         "ts-mixer": "^6.0.4",
-        "yaml": "^2.8.4"
+        "yaml": "^2.9.0"
       }
     },
     "node_modules/@speclynx/apidom-datamodel": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-datamodel/-/apidom-datamodel-4.10.0.tgz",
-      "integrity": "sha512-VMwKRzlyuoScoyVXaXeB9xSLJ7aY9RMETYHqHPJqk8liqXCSm+UuFD4JBMPXOYliETOaVJL66CCtpv1Lo9Riwg==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-datamodel/-/apidom-datamodel-4.11.1.tgz",
+      "integrity": "sha512-ene/s1rJHCh+DNa4cm9JI6COsdyty23q1JPLINSGrfC7OLERoILul0cBdJgaoiE0J/yYp2+X21Hjbu5HomxpqQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-error": "4.10.0",
+        "@babel/runtime-corejs3": "^7.29.7",
+        "@speclynx/apidom-error": "4.11.1",
         "ramda": "~0.32.0"
       }
     },
     "node_modules/@speclynx/apidom-error": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-error/-/apidom-error-4.10.0.tgz",
-      "integrity": "sha512-URtLF8+nL87xBG8hmEnAkyftCjFi1pUE4mbTn1W3NVHptJql9RA8ynHyrGyUE8hWdjhptn01cq6t//cqv/nuRA==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-error/-/apidom-error-4.11.1.tgz",
+      "integrity": "sha512-45+Kyf65Id2hDz+gLHvFvnn3y1Nv8bwHAda3ros37PZodNc9Y5jQWlQCh3VE69RoEALpgbW+NsgchyLGp3CJYg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "^7.28.4"
+        "@babel/runtime-corejs3": "^7.29.7"
       }
     },
     "node_modules/@speclynx/apidom-json-path": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-json-path/-/apidom-json-path-4.10.0.tgz",
-      "integrity": "sha512-F6BBXnvcb2eC5Kq1xJ0anhq+8GSXSvmGFV+//JiC4gg9gXf/6X8a0UBhNDVja20LMQVgmLNx5GPgRXAGcA7o7w==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-json-path/-/apidom-json-path-4.11.1.tgz",
+      "integrity": "sha512-Tfl7P1xCU3mHmOGJY3QSuwv0JbpbYtrIwVu6xFxdlEZ7KbZq58dR5U/ZlGdhAW4ApjAe654Toj6JETCHOQMieQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-datamodel": "4.10.0",
-        "@speclynx/apidom-error": "4.10.0",
+        "@babel/runtime-corejs3": "^7.29.7",
+        "@speclynx/apidom-datamodel": "4.11.1",
+        "@speclynx/apidom-error": "4.11.1",
         "@swaggerexpert/jsonpath": "^4.0.4"
       }
     },
     "node_modules/@speclynx/apidom-json-pointer": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-json-pointer/-/apidom-json-pointer-4.10.0.tgz",
-      "integrity": "sha512-7BTGA7FRNv8wQZEYH6rPaWf8rfd9QThLGzu9FGDNIT5RhHnrHMrkxTs2qP4UGifs9lTTbSrKleo9Bu+lANHUsQ==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-json-pointer/-/apidom-json-pointer-4.11.1.tgz",
+      "integrity": "sha512-wEEZYkoShF4vplHp8omXtxgSwSy5lD/Xb59a9FbKrjOMl4uPGFSV6yjUmaTKG5cSchW8O6n87J5JEoh147Song==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-datamodel": "4.10.0",
-        "@speclynx/apidom-error": "4.10.0",
+        "@babel/runtime-corejs3": "^7.29.7",
+        "@speclynx/apidom-datamodel": "4.11.1",
+        "@speclynx/apidom-error": "4.11.1",
         "@swaggerexpert/json-pointer": "^3.0.1"
       }
     },
     "node_modules/@speclynx/apidom-ns-arazzo-1": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-arazzo-1/-/apidom-ns-arazzo-1-4.10.0.tgz",
-      "integrity": "sha512-HObK4+SzfYuRtJtksrg/Wk5P12Pq/12goR11wrRDHa5kKDeyUQGVmifyMIOu4tLyob9h6oe2J3mpwb6mRJ40hg==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-arazzo-1/-/apidom-ns-arazzo-1-4.11.1.tgz",
+      "integrity": "sha512-F++KYJOtJAg7Lxu3IwPr/JhSb5DwDHuuWIa1iwsgaN3r2KWyRu/rmfnBZNuBSVgY9lwS5eQNgYWgTr88pwiW9A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.10.0",
-        "@speclynx/apidom-datamodel": "4.10.0",
-        "@speclynx/apidom-ns-json-schema-2020-12": "4.10.0",
-        "@speclynx/apidom-traverse": "4.10.0",
+        "@babel/runtime-corejs3": "^7.29.7",
+        "@speclynx/apidom-core": "4.11.1",
+        "@speclynx/apidom-datamodel": "4.11.1",
+        "@speclynx/apidom-ns-json-schema-2020-12": "4.11.1",
+        "@speclynx/apidom-traverse": "4.11.1",
         "ramda": "~0.32.0",
-        "ramda-adjunct": "^6.0.0",
+        "ramda-adjunct": "^6.1.0",
         "ts-mixer": "^6.0.4"
       }
     },
     "node_modules/@speclynx/apidom-ns-asyncapi-2": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-asyncapi-2/-/apidom-ns-asyncapi-2-4.10.0.tgz",
-      "integrity": "sha512-p2xGHzaiinCYjb9ILqKQhen34KECJr7U7RhzMS8NflUWF2vxW2+bdLi6UYixwvgsViMQMfLCCgh1j2LKS1bOzw==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-asyncapi-2/-/apidom-ns-asyncapi-2-4.11.1.tgz",
+      "integrity": "sha512-450+IcRtWoIlft/6x5usyBJefcSGS+gSiu7hWGOLzcAjqYu6+7DTY2IZOM9Ji78HZiKyecE5oRxAK+a/rwIGdA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.10.0",
-        "@speclynx/apidom-datamodel": "4.10.0",
-        "@speclynx/apidom-ns-json-schema-draft-7": "4.10.0",
-        "@speclynx/apidom-traverse": "4.10.0",
+        "@babel/runtime-corejs3": "^7.29.7",
+        "@speclynx/apidom-core": "4.11.1",
+        "@speclynx/apidom-datamodel": "4.11.1",
+        "@speclynx/apidom-ns-json-schema-draft-7": "4.11.1",
+        "@speclynx/apidom-traverse": "4.11.1",
         "ramda": "~0.32.0",
-        "ramda-adjunct": "^6.0.0",
+        "ramda-adjunct": "^6.1.0",
         "ts-mixer": "^6.0.4"
       }
     },
     "node_modules/@speclynx/apidom-ns-json-schema-2019-09": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-json-schema-2019-09/-/apidom-ns-json-schema-2019-09-4.10.0.tgz",
-      "integrity": "sha512-0V5W7ysh+sEmBb0emZMHBUrzJt7oH/q93OM7qgNDkl3FtQlDGLPzpQ+lVe9hkbzKlCKc4+pZihqp257Qr0UYPw==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-json-schema-2019-09/-/apidom-ns-json-schema-2019-09-4.11.1.tgz",
+      "integrity": "sha512-hWqWUjvxssqUcEgAOGInhgsSdjzrzfu5ivQCxXrTpkMBJivR6O2OQgFI5fHAJTkBWIuE2CnRMVkGX+JQd+8QBw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.10.0",
-        "@speclynx/apidom-datamodel": "4.10.0",
-        "@speclynx/apidom-error": "4.10.0",
-        "@speclynx/apidom-ns-json-schema-draft-6": "4.10.0",
-        "@speclynx/apidom-ns-json-schema-draft-7": "4.10.0",
-        "@speclynx/apidom-traverse": "4.10.0",
+        "@babel/runtime-corejs3": "^7.29.7",
+        "@speclynx/apidom-core": "4.11.1",
+        "@speclynx/apidom-datamodel": "4.11.1",
+        "@speclynx/apidom-error": "4.11.1",
+        "@speclynx/apidom-ns-json-schema-draft-6": "4.11.1",
+        "@speclynx/apidom-ns-json-schema-draft-7": "4.11.1",
+        "@speclynx/apidom-traverse": "4.11.1",
         "ramda": "~0.32.0",
-        "ramda-adjunct": "^6.0.0",
+        "ramda-adjunct": "^6.1.0",
         "ts-mixer": "^6.0.4"
       }
     },
     "node_modules/@speclynx/apidom-ns-json-schema-2020-12": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-json-schema-2020-12/-/apidom-ns-json-schema-2020-12-4.10.0.tgz",
-      "integrity": "sha512-M0hasmQ9LoGo4W/wjpkLuPOf5U8HWDxdNEUsEjsGawZCcTfFkG1+RiGRqbKFtMW+Fo2Q1CqnRCAvn6vM7foNuA==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-json-schema-2020-12/-/apidom-ns-json-schema-2020-12-4.11.1.tgz",
+      "integrity": "sha512-BF8FukJE4pb6h60QxQZB9GY9tQclAfsGMm6uRF16YZ9emAZ6uBUZ8fGhaFowPu6e2w3bamPuO+nMNpYYuYE51g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.10.0",
-        "@speclynx/apidom-datamodel": "4.10.0",
-        "@speclynx/apidom-error": "4.10.0",
-        "@speclynx/apidom-ns-json-schema-2019-09": "4.10.0",
-        "@speclynx/apidom-traverse": "4.10.0",
+        "@babel/runtime-corejs3": "^7.29.7",
+        "@speclynx/apidom-core": "4.11.1",
+        "@speclynx/apidom-datamodel": "4.11.1",
+        "@speclynx/apidom-error": "4.11.1",
+        "@speclynx/apidom-ns-json-schema-2019-09": "4.11.1",
+        "@speclynx/apidom-traverse": "4.11.1",
         "ramda": "~0.32.0",
-        "ramda-adjunct": "^6.0.0",
+        "ramda-adjunct": "^6.1.0",
         "ts-mixer": "^6.0.4"
       }
     },
     "node_modules/@speclynx/apidom-ns-json-schema-draft-4": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-json-schema-draft-4/-/apidom-ns-json-schema-draft-4-4.10.0.tgz",
-      "integrity": "sha512-l3y8z7aw+veAx5SSOuGW5ksc6ALyZ3ZSdx2QeJPtAVRaBzr9PJ13j6x4P1hf6NjcXiERZ/PlahatJqMQXy3U0g==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-json-schema-draft-4/-/apidom-ns-json-schema-draft-4-4.11.1.tgz",
+      "integrity": "sha512-Ku1NZRyw5tefMCt27QXjT0OipoWMd5GIYLSASsa4vJuCcqP2aVuSG9H8EL+WW8Ty1mePRNnCfnQbyKLn2VGVzw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.10.0",
-        "@speclynx/apidom-datamodel": "4.10.0",
-        "@speclynx/apidom-traverse": "4.10.0",
+        "@babel/runtime-corejs3": "^7.29.7",
+        "@speclynx/apidom-core": "4.11.1",
+        "@speclynx/apidom-datamodel": "4.11.1",
+        "@speclynx/apidom-traverse": "4.11.1",
         "ramda": "~0.32.0",
-        "ramda-adjunct": "^6.0.0",
+        "ramda-adjunct": "^6.1.0",
         "ts-mixer": "^6.0.4"
       }
     },
     "node_modules/@speclynx/apidom-ns-json-schema-draft-6": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-json-schema-draft-6/-/apidom-ns-json-schema-draft-6-4.10.0.tgz",
-      "integrity": "sha512-tDUjpqvQGz9pnLVTC40wiJa4z+2m37q7AaZhYdJNAZay1uo+h++80rOO3wUah6KGY671rGMamj/sCdT7wezK6Q==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-json-schema-draft-6/-/apidom-ns-json-schema-draft-6-4.11.1.tgz",
+      "integrity": "sha512-Y4R3Wx68WBhjD/adjZZngqTlZzcppTsmKyfrmBSS7fE9x/g29FIemgR9CBz8sBAJZYV7xSCSyfBwtHKLu3YBbA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.10.0",
-        "@speclynx/apidom-datamodel": "4.10.0",
-        "@speclynx/apidom-error": "4.10.0",
-        "@speclynx/apidom-ns-json-schema-draft-4": "4.10.0",
-        "@speclynx/apidom-traverse": "4.10.0",
+        "@babel/runtime-corejs3": "^7.29.7",
+        "@speclynx/apidom-core": "4.11.1",
+        "@speclynx/apidom-datamodel": "4.11.1",
+        "@speclynx/apidom-error": "4.11.1",
+        "@speclynx/apidom-ns-json-schema-draft-4": "4.11.1",
+        "@speclynx/apidom-traverse": "4.11.1",
         "ramda": "~0.32.0",
-        "ramda-adjunct": "^6.0.0",
+        "ramda-adjunct": "^6.1.0",
         "ts-mixer": "^6.0.4"
       }
     },
     "node_modules/@speclynx/apidom-ns-json-schema-draft-7": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-json-schema-draft-7/-/apidom-ns-json-schema-draft-7-4.10.0.tgz",
-      "integrity": "sha512-PpwIb/tWbl2Nl7nw/AHm4a7qLxbES4bzBwIiJd3qEEGiNUOzhdo17OW9i/EOXHSLaCRKSBjaAyz1psfK0kbZqw==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-json-schema-draft-7/-/apidom-ns-json-schema-draft-7-4.11.1.tgz",
+      "integrity": "sha512-QURWkS3vhfTSV8J3iYgR/qBf5+fC3R420dMIAGF0GYKfXtassaEKL1Q9iW0fcS3ZlK9nw+OTmWTYVMMYGTgYWw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.10.0",
-        "@speclynx/apidom-datamodel": "4.10.0",
-        "@speclynx/apidom-error": "4.10.0",
-        "@speclynx/apidom-ns-json-schema-draft-6": "4.10.0",
-        "@speclynx/apidom-traverse": "4.10.0",
+        "@babel/runtime-corejs3": "^7.29.7",
+        "@speclynx/apidom-core": "4.11.1",
+        "@speclynx/apidom-datamodel": "4.11.1",
+        "@speclynx/apidom-error": "4.11.1",
+        "@speclynx/apidom-ns-json-schema-draft-6": "4.11.1",
+        "@speclynx/apidom-traverse": "4.11.1",
         "ramda": "~0.32.0",
-        "ramda-adjunct": "^6.0.0",
+        "ramda-adjunct": "^6.1.0",
         "ts-mixer": "^6.0.4"
       }
     },
     "node_modules/@speclynx/apidom-ns-openapi-2": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-openapi-2/-/apidom-ns-openapi-2-4.10.0.tgz",
-      "integrity": "sha512-amk2l48abT7WoLMrEj/bwoZRoJn6ZKwQ2vnE5RRkI74x10MHB3yk1RbyyVFJLMd2lQ23K8bVqR36HuUPOfEe/A==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-openapi-2/-/apidom-ns-openapi-2-4.11.1.tgz",
+      "integrity": "sha512-ppzRvU8m0NcdXN8qej+x7oIPbI7laPlIDBAtkmfRxoBHoWEY5BmS9a3pldkswZSR5knPfhgOAohqMw3iKGwgJA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.10.0",
-        "@speclynx/apidom-datamodel": "4.10.0",
-        "@speclynx/apidom-error": "4.10.0",
-        "@speclynx/apidom-json-pointer": "4.10.0",
-        "@speclynx/apidom-ns-json-schema-draft-4": "4.10.0",
-        "@speclynx/apidom-traverse": "4.10.0",
+        "@babel/runtime-corejs3": "^7.29.7",
+        "@speclynx/apidom-core": "4.11.1",
+        "@speclynx/apidom-datamodel": "4.11.1",
+        "@speclynx/apidom-error": "4.11.1",
+        "@speclynx/apidom-json-pointer": "4.11.1",
+        "@speclynx/apidom-ns-json-schema-draft-4": "4.11.1",
+        "@speclynx/apidom-traverse": "4.11.1",
         "ramda": "~0.32.0",
-        "ramda-adjunct": "^6.0.0",
+        "ramda-adjunct": "^6.1.0",
         "ts-mixer": "^6.0.4"
       }
     },
     "node_modules/@speclynx/apidom-ns-openapi-3-0": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-openapi-3-0/-/apidom-ns-openapi-3-0-4.10.0.tgz",
-      "integrity": "sha512-JmZoVvq2mr7JPsOGHHr9C3Rk/bepaQX8J2qoWo7AvbG6EXcKQF2q1My7Q77QsGAoCSdbrRplTlimFxSsEMm8WA==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-openapi-3-0/-/apidom-ns-openapi-3-0-4.11.1.tgz",
+      "integrity": "sha512-OIF5j5qRIqWdLQX+GfPnHytOOornC6TipVkuAa82Sihl6nD7fxHQ9uiyXfmdBVl4F6VGHN+BNF5P8Ie+OZNEUQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.10.0",
-        "@speclynx/apidom-datamodel": "4.10.0",
-        "@speclynx/apidom-error": "4.10.0",
-        "@speclynx/apidom-json-pointer": "4.10.0",
-        "@speclynx/apidom-ns-json-schema-draft-4": "4.10.0",
-        "@speclynx/apidom-traverse": "4.10.0",
+        "@babel/runtime-corejs3": "^7.29.7",
+        "@speclynx/apidom-core": "4.11.1",
+        "@speclynx/apidom-datamodel": "4.11.1",
+        "@speclynx/apidom-error": "4.11.1",
+        "@speclynx/apidom-json-pointer": "4.11.1",
+        "@speclynx/apidom-ns-json-schema-draft-4": "4.11.1",
+        "@speclynx/apidom-traverse": "4.11.1",
         "ramda": "~0.32.0",
-        "ramda-adjunct": "^6.0.0",
+        "ramda-adjunct": "^6.1.0",
         "ts-mixer": "^6.0.4"
       }
     },
     "node_modules/@speclynx/apidom-ns-openapi-3-1": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-openapi-3-1/-/apidom-ns-openapi-3-1-4.10.0.tgz",
-      "integrity": "sha512-naKHDVQ1Ajlwoirt9cYsHO3Sic1pjIyLqF1Y+qt/g3jo68sy/oPtWE1CjvHnuSqA64hpkoSL2rVgmDkwWardYw==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-openapi-3-1/-/apidom-ns-openapi-3-1-4.11.1.tgz",
+      "integrity": "sha512-9q0foeHbsN+jcWa4fzdGfHibvevaYa3VrTJxA0bqNYDdQUM6RFSb3DfI9DeW1x7DpVe200JXhc5pBhXrSDGniQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.10.0",
-        "@speclynx/apidom-datamodel": "4.10.0",
-        "@speclynx/apidom-json-pointer": "4.10.0",
-        "@speclynx/apidom-ns-json-schema-2020-12": "4.10.0",
-        "@speclynx/apidom-ns-openapi-3-0": "4.10.0",
-        "@speclynx/apidom-traverse": "4.10.0",
+        "@babel/runtime-corejs3": "^7.29.7",
+        "@speclynx/apidom-core": "4.11.1",
+        "@speclynx/apidom-datamodel": "4.11.1",
+        "@speclynx/apidom-json-pointer": "4.11.1",
+        "@speclynx/apidom-ns-json-schema-2020-12": "4.11.1",
+        "@speclynx/apidom-ns-openapi-3-0": "4.11.1",
+        "@speclynx/apidom-traverse": "4.11.1",
         "ramda": "~0.32.0",
-        "ramda-adjunct": "^6.0.0",
+        "ramda-adjunct": "^6.1.0",
         "ts-mixer": "^6.0.4"
       }
     },
     "node_modules/@speclynx/apidom-ns-overlay-1": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-overlay-1/-/apidom-ns-overlay-1-4.10.0.tgz",
-      "integrity": "sha512-dLD2bXDHCqwUQM69ftiMoTf4FzDwBRDXQRzxVxn/pd61d20nJDRpyXuQ+Q+Vh2uZ9/k4y0v2B2ed5qv8BLZh4A==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-ns-overlay-1/-/apidom-ns-overlay-1-4.11.1.tgz",
+      "integrity": "sha512-0Po5LarC1+BUr7OsJMQqwr1oM31rHQcz3ZXkNnmcuyhyK9EZZdPIKk7YxtCPrgc4pbx16tpZhnm5MiZmfpcuaw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.10.0",
-        "@speclynx/apidom-datamodel": "4.10.0",
-        "@speclynx/apidom-traverse": "4.10.0",
+        "@babel/runtime-corejs3": "^7.29.7",
+        "@speclynx/apidom-core": "4.11.1",
+        "@speclynx/apidom-datamodel": "4.11.1",
+        "@speclynx/apidom-traverse": "4.11.1",
         "ramda": "~0.32.0",
-        "ramda-adjunct": "^6.0.0",
+        "ramda-adjunct": "^6.1.0",
         "ts-mixer": "^6.0.4"
       }
     },
     "node_modules/@speclynx/apidom-parser-adapter-arazzo-json-1": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-arazzo-json-1/-/apidom-parser-adapter-arazzo-json-1-4.10.0.tgz",
-      "integrity": "sha512-BFP6S7JQ5vnHglOLX+xG9647W6npemR8manJ3t1jd2Hwieeug0/olYP7xjgigRH0vyTtE6EtehZwmJs8abFdkA==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-arazzo-json-1/-/apidom-parser-adapter-arazzo-json-1-4.11.1.tgz",
+      "integrity": "sha512-9Tky5vOMuMupJgdx2VmSCi8b4YazF8pCWC7S4lf/MqCJeYULaCIufKRn1xf38qx3PM1+5AuUksZeY1aQLMhMvQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.10.0",
-        "@speclynx/apidom-datamodel": "4.10.0",
-        "@speclynx/apidom-ns-arazzo-1": "4.10.0",
-        "@speclynx/apidom-parser-adapter-json": "4.10.0",
+        "@babel/runtime-corejs3": "^7.29.7",
+        "@speclynx/apidom-core": "4.11.1",
+        "@speclynx/apidom-datamodel": "4.11.1",
+        "@speclynx/apidom-ns-arazzo-1": "4.11.1",
+        "@speclynx/apidom-parser-adapter-json": "4.11.1",
         "ramda": "~0.32.0",
-        "ramda-adjunct": "^6.0.0"
+        "ramda-adjunct": "^6.1.0"
       }
     },
     "node_modules/@speclynx/apidom-parser-adapter-arazzo-yaml-1": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-arazzo-yaml-1/-/apidom-parser-adapter-arazzo-yaml-1-4.10.0.tgz",
-      "integrity": "sha512-6xhJsPCBn5OMjPLlNm7+HDb/pPXi0dq1SBMzGEM3enakp8WU+4yUEgqm8XjbfGHWbovOBTCoMufzclsWJzrIOQ==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-arazzo-yaml-1/-/apidom-parser-adapter-arazzo-yaml-1-4.11.1.tgz",
+      "integrity": "sha512-Wkba4B+SH8LKbHqahQElk4dNJPCG0ZzD2KKrKJaOMzptCeX0/HJ2wdFLTa3mUcfQIX+dmJPPQjHkmanrqmc4pw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.10.0",
-        "@speclynx/apidom-datamodel": "4.10.0",
-        "@speclynx/apidom-ns-arazzo-1": "4.10.0",
-        "@speclynx/apidom-parser-adapter-yaml-1-2": "4.10.0",
+        "@babel/runtime-corejs3": "^7.29.7",
+        "@speclynx/apidom-core": "4.11.1",
+        "@speclynx/apidom-datamodel": "4.11.1",
+        "@speclynx/apidom-ns-arazzo-1": "4.11.1",
+        "@speclynx/apidom-parser-adapter-yaml-1-2": "4.11.1",
         "ramda": "~0.32.0",
-        "ramda-adjunct": "^6.0.0"
+        "ramda-adjunct": "^6.1.0"
       }
     },
     "node_modules/@speclynx/apidom-parser-adapter-asyncapi-json-2": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-asyncapi-json-2/-/apidom-parser-adapter-asyncapi-json-2-4.10.0.tgz",
-      "integrity": "sha512-yoXVK1UooT+/TzQpvuk/CxdZaQX5nqJ7kzIouopoI9EmHQpdIvp+gtoBNumhtXKU1wAi9CQuF9ahmpzCfo9Ucw==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-asyncapi-json-2/-/apidom-parser-adapter-asyncapi-json-2-4.11.1.tgz",
+      "integrity": "sha512-FQTFDI2H7CCSpzcnhLza+jgwerLrF1/usW8Bk9m8mmKjEHA2blI9/5Zv0pKbgq1akSKzMLXlJKnQSXn8TgvtAw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.10.0",
-        "@speclynx/apidom-datamodel": "4.10.0",
-        "@speclynx/apidom-ns-asyncapi-2": "4.10.0",
-        "@speclynx/apidom-parser-adapter-json": "4.10.0",
+        "@babel/runtime-corejs3": "^7.29.7",
+        "@speclynx/apidom-core": "4.11.1",
+        "@speclynx/apidom-datamodel": "4.11.1",
+        "@speclynx/apidom-ns-asyncapi-2": "4.11.1",
+        "@speclynx/apidom-parser-adapter-json": "4.11.1",
         "ramda": "~0.32.0",
-        "ramda-adjunct": "^6.0.0"
+        "ramda-adjunct": "^6.1.0"
       }
     },
     "node_modules/@speclynx/apidom-parser-adapter-asyncapi-yaml-2": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-asyncapi-yaml-2/-/apidom-parser-adapter-asyncapi-yaml-2-4.10.0.tgz",
-      "integrity": "sha512-pHC7LCUxW+aC7PKI/HGcJOtuxUr/ZJgaSaUPxy9IBpA3ktUMw57luXW1ufNBb7aSbrkUY2E8ESwx/nJMUv4ZvA==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-asyncapi-yaml-2/-/apidom-parser-adapter-asyncapi-yaml-2-4.11.1.tgz",
+      "integrity": "sha512-m7FdoKBL6vFAsLY2fho1akKpBQ5NubqiF6XdOhv+0fz8+uxNaA6zhBz5VMw5dYt91NUbz88oxaAtaPp4yg1eyQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.10.0",
-        "@speclynx/apidom-datamodel": "4.10.0",
-        "@speclynx/apidom-ns-asyncapi-2": "4.10.0",
-        "@speclynx/apidom-parser-adapter-yaml-1-2": "4.10.0",
+        "@babel/runtime-corejs3": "^7.29.7",
+        "@speclynx/apidom-core": "4.11.1",
+        "@speclynx/apidom-datamodel": "4.11.1",
+        "@speclynx/apidom-ns-asyncapi-2": "4.11.1",
+        "@speclynx/apidom-parser-adapter-yaml-1-2": "4.11.1",
         "ramda": "~0.32.0",
-        "ramda-adjunct": "^6.0.0"
+        "ramda-adjunct": "^6.1.0"
       }
     },
     "node_modules/@speclynx/apidom-parser-adapter-json": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-json/-/apidom-parser-adapter-json-4.10.0.tgz",
-      "integrity": "sha512-mRjHqNMnU+GQsacmGHuRjh6mSZAHYVFz8V/ztfnlAh7xiO46nc4Ggdn+ZFawsnCRASCYz5g5j6f24QVTmO/9gQ==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-json/-/apidom-parser-adapter-json-4.11.1.tgz",
+      "integrity": "sha512-P+Hsc1zNGlgUbhT3yL7hpeFfaodvY70wr2trxc5w/h+6OmOk4NDo6lD1nNECwwMlYvwOcbhXU2ziEzoMQjqNTA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.10.0",
-        "@speclynx/apidom-datamodel": "4.10.0",
-        "@speclynx/apidom-error": "4.10.0",
-        "web-tree-sitter": "=0.26.8"
+        "@babel/runtime-corejs3": "^7.29.7",
+        "@speclynx/apidom-core": "4.11.1",
+        "@speclynx/apidom-datamodel": "4.11.1",
+        "@speclynx/apidom-error": "4.11.1",
+        "web-tree-sitter": "=0.26.9"
       }
     },
     "node_modules/@speclynx/apidom-parser-adapter-openapi-json-2": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-openapi-json-2/-/apidom-parser-adapter-openapi-json-2-4.10.0.tgz",
-      "integrity": "sha512-PNCFKrhv3ZjQjyDzLNDYCDuminGOZ1uyJh5bCwgSsyO60Lbt4zzRPbbCVyXue7UPGDI2hLQaVzuZSkt+HO04Aw==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-openapi-json-2/-/apidom-parser-adapter-openapi-json-2-4.11.1.tgz",
+      "integrity": "sha512-jzZw1ZfKXWq7QVB3EFf1GWSTv2Z591nQ5Ie1gC5k1aoDdXxVm8rpscYh4HyARszZKrVFvLWbQxpxgWCEqMRvxA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.10.0",
-        "@speclynx/apidom-datamodel": "4.10.0",
-        "@speclynx/apidom-ns-openapi-2": "4.10.0",
-        "@speclynx/apidom-parser-adapter-json": "4.10.0",
+        "@babel/runtime-corejs3": "^7.29.7",
+        "@speclynx/apidom-core": "4.11.1",
+        "@speclynx/apidom-datamodel": "4.11.1",
+        "@speclynx/apidom-ns-openapi-2": "4.11.1",
+        "@speclynx/apidom-parser-adapter-json": "4.11.1",
         "ramda": "~0.32.0",
-        "ramda-adjunct": "^6.0.0"
+        "ramda-adjunct": "^6.1.0"
       }
     },
     "node_modules/@speclynx/apidom-parser-adapter-openapi-json-3-0": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-openapi-json-3-0/-/apidom-parser-adapter-openapi-json-3-0-4.10.0.tgz",
-      "integrity": "sha512-Z6k8ZceuB709s7y0PzzdqfpDGFPLV6Ue3J5Ue17Xi5QDGsMdsUruzzjtfr4e/4l+sERHdRKLhoERfk/EoQ1/5w==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-openapi-json-3-0/-/apidom-parser-adapter-openapi-json-3-0-4.11.1.tgz",
+      "integrity": "sha512-gm6i1iZbmXHBa19wKNN3OHkvcaZ3/njm52MY50VOIZt/GTZdVZfx31adpi9tjcdwqlRRV5UXcs4yHNC7zEAXBg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.10.0",
-        "@speclynx/apidom-datamodel": "4.10.0",
-        "@speclynx/apidom-ns-openapi-3-0": "4.10.0",
-        "@speclynx/apidom-parser-adapter-json": "4.10.0",
+        "@babel/runtime-corejs3": "^7.29.7",
+        "@speclynx/apidom-core": "4.11.1",
+        "@speclynx/apidom-datamodel": "4.11.1",
+        "@speclynx/apidom-ns-openapi-3-0": "4.11.1",
+        "@speclynx/apidom-parser-adapter-json": "4.11.1",
         "ramda": "~0.32.0",
-        "ramda-adjunct": "^6.0.0"
+        "ramda-adjunct": "^6.1.0"
       }
     },
     "node_modules/@speclynx/apidom-parser-adapter-openapi-json-3-1": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-openapi-json-3-1/-/apidom-parser-adapter-openapi-json-3-1-4.10.0.tgz",
-      "integrity": "sha512-GEGgxpzGd61HjKdDlWojdXnQn/4WoIf7SiSTifgSuthGH0GorhE6z3Og3g0cVM7NAgNrZnec3LelFAZURKm3QA==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-openapi-json-3-1/-/apidom-parser-adapter-openapi-json-3-1-4.11.1.tgz",
+      "integrity": "sha512-uO7hDGzLaC1pDY6hgUVNZGYr4LjPhtCbM1VKA9aJEe6iV9ELyQLAKWAAQdXv/QRBAr+VtymzP+o/7O5J6M18Dg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.10.0",
-        "@speclynx/apidom-datamodel": "4.10.0",
-        "@speclynx/apidom-ns-openapi-3-1": "4.10.0",
-        "@speclynx/apidom-parser-adapter-json": "4.10.0",
+        "@babel/runtime-corejs3": "^7.29.7",
+        "@speclynx/apidom-core": "4.11.1",
+        "@speclynx/apidom-datamodel": "4.11.1",
+        "@speclynx/apidom-ns-openapi-3-1": "4.11.1",
+        "@speclynx/apidom-parser-adapter-json": "4.11.1",
         "ramda": "~0.32.0",
-        "ramda-adjunct": "^6.0.0"
+        "ramda-adjunct": "^6.1.0"
       }
     },
     "node_modules/@speclynx/apidom-parser-adapter-openapi-yaml-2": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-openapi-yaml-2/-/apidom-parser-adapter-openapi-yaml-2-4.10.0.tgz",
-      "integrity": "sha512-O+L4VVV75KQ8+a6ekozXb/XWdnDHLIsTnq1nWZGLjiwWgBRUv8jf/78epvmkNQx641f9YN/BpumBVvQQgpBI8g==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-openapi-yaml-2/-/apidom-parser-adapter-openapi-yaml-2-4.11.1.tgz",
+      "integrity": "sha512-g84xTjQPkQQrP2BGCzLvoc0/ZbW1htP1qWS+8E2cmtvd+EVH9Tcn9WgNuRkb2J3CPr1D4lu3ZueVGHW4CsUyMQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.10.0",
-        "@speclynx/apidom-datamodel": "4.10.0",
-        "@speclynx/apidom-ns-openapi-2": "4.10.0",
-        "@speclynx/apidom-parser-adapter-yaml-1-2": "4.10.0",
+        "@babel/runtime-corejs3": "^7.29.7",
+        "@speclynx/apidom-core": "4.11.1",
+        "@speclynx/apidom-datamodel": "4.11.1",
+        "@speclynx/apidom-ns-openapi-2": "4.11.1",
+        "@speclynx/apidom-parser-adapter-yaml-1-2": "4.11.1",
         "ramda": "~0.32.0",
-        "ramda-adjunct": "^6.0.0"
+        "ramda-adjunct": "^6.1.0"
       }
     },
     "node_modules/@speclynx/apidom-parser-adapter-openapi-yaml-3-0": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-openapi-yaml-3-0/-/apidom-parser-adapter-openapi-yaml-3-0-4.10.0.tgz",
-      "integrity": "sha512-hvs0Dcgqq/po9huO92SZSCMZYjWsVkv9ZWj1GTc0Mv+dT8hkQxAklQeJQl+4UQoq6IohseqkVJ8T0Rm4jSyMzA==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-openapi-yaml-3-0/-/apidom-parser-adapter-openapi-yaml-3-0-4.11.1.tgz",
+      "integrity": "sha512-vIPhYS9AtVKBIdIu4uii8Yv1OgCGMH1Nh3Itf6tr+H1qCiEaolc7a/EBYMWeM+ZtNzDCgXtxEbFX1R3n7d+kKA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.10.0",
-        "@speclynx/apidom-datamodel": "4.10.0",
-        "@speclynx/apidom-ns-openapi-3-0": "4.10.0",
-        "@speclynx/apidom-parser-adapter-yaml-1-2": "4.10.0",
+        "@babel/runtime-corejs3": "^7.29.7",
+        "@speclynx/apidom-core": "4.11.1",
+        "@speclynx/apidom-datamodel": "4.11.1",
+        "@speclynx/apidom-ns-openapi-3-0": "4.11.1",
+        "@speclynx/apidom-parser-adapter-yaml-1-2": "4.11.1",
         "ramda": "~0.32.0",
-        "ramda-adjunct": "^6.0.0"
+        "ramda-adjunct": "^6.1.0"
       }
     },
     "node_modules/@speclynx/apidom-parser-adapter-openapi-yaml-3-1": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-openapi-yaml-3-1/-/apidom-parser-adapter-openapi-yaml-3-1-4.10.0.tgz",
-      "integrity": "sha512-WsP9SyBGgu7QAarg5IyVgDt4fi6jU7OT60fxQD75FzY1Wd2R8hOLAjHig7GLTynM8QOChgZYQEGFG0Yb0+oBdg==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-openapi-yaml-3-1/-/apidom-parser-adapter-openapi-yaml-3-1-4.11.1.tgz",
+      "integrity": "sha512-Rjo1YrpsPE5ud0g9jr95ChrAq0Ug8VDVbgWE4FF10qoCw6w+ceI3N+12aLDLI5pMr5YkoTJwm1cZaeppB9PVVg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.10.0",
-        "@speclynx/apidom-datamodel": "4.10.0",
-        "@speclynx/apidom-ns-openapi-3-1": "4.10.0",
-        "@speclynx/apidom-parser-adapter-yaml-1-2": "4.10.0",
+        "@babel/runtime-corejs3": "^7.29.7",
+        "@speclynx/apidom-core": "4.11.1",
+        "@speclynx/apidom-datamodel": "4.11.1",
+        "@speclynx/apidom-ns-openapi-3-1": "4.11.1",
+        "@speclynx/apidom-parser-adapter-yaml-1-2": "4.11.1",
         "ramda": "~0.32.0",
-        "ramda-adjunct": "^6.0.0"
+        "ramda-adjunct": "^6.1.0"
       }
     },
     "node_modules/@speclynx/apidom-parser-adapter-overlay-json-1": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-overlay-json-1/-/apidom-parser-adapter-overlay-json-1-4.10.0.tgz",
-      "integrity": "sha512-IFEiqWEvj294gKlb2inV8ZIrKOt2Ox5FaMk0XvVirUCHDwA6OBelnsuIk9dh14/Wp+xw8S/+ozv3NxD/p6V29g==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-overlay-json-1/-/apidom-parser-adapter-overlay-json-1-4.11.1.tgz",
+      "integrity": "sha512-+KA+W1aYavgv9lp+iVjRewpOjpONASI7kuJz13e+HnHzVDGowOaUr4g0TDjjiHShUawrkk+XN2Zvy4eJ2sVpMA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.10.0",
-        "@speclynx/apidom-datamodel": "4.10.0",
-        "@speclynx/apidom-ns-overlay-1": "4.10.0",
-        "@speclynx/apidom-parser-adapter-json": "4.10.0",
+        "@babel/runtime-corejs3": "^7.29.7",
+        "@speclynx/apidom-core": "4.11.1",
+        "@speclynx/apidom-datamodel": "4.11.1",
+        "@speclynx/apidom-ns-overlay-1": "4.11.1",
+        "@speclynx/apidom-parser-adapter-json": "4.11.1",
         "ramda": "~0.32.0",
-        "ramda-adjunct": "^6.0.0"
+        "ramda-adjunct": "^6.1.0"
       }
     },
     "node_modules/@speclynx/apidom-parser-adapter-overlay-yaml-1": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-overlay-yaml-1/-/apidom-parser-adapter-overlay-yaml-1-4.10.0.tgz",
-      "integrity": "sha512-Kclu9Xa+m2cy5pp31Ku5SABaJvq+cPer42/4TGYJF/AB5nVLjoG0jVnndB1P5gViaWnrqhFj57BpTiaHcPULLA==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-overlay-yaml-1/-/apidom-parser-adapter-overlay-yaml-1-4.11.1.tgz",
+      "integrity": "sha512-29W9PhFidt4Os9KEzVu6KsE9pvALSVoYZWmAAhM4QKI3LPrYClE+8rZcirguUJcGoCmOT7iyNlNbBKL/gtLeuQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.10.0",
-        "@speclynx/apidom-datamodel": "4.10.0",
-        "@speclynx/apidom-ns-overlay-1": "4.10.0",
-        "@speclynx/apidom-parser-adapter-yaml-1-2": "4.10.0",
+        "@babel/runtime-corejs3": "^7.29.7",
+        "@speclynx/apidom-core": "4.11.1",
+        "@speclynx/apidom-datamodel": "4.11.1",
+        "@speclynx/apidom-ns-overlay-1": "4.11.1",
+        "@speclynx/apidom-parser-adapter-yaml-1-2": "4.11.1",
         "ramda": "~0.32.0",
-        "ramda-adjunct": "^6.0.0"
+        "ramda-adjunct": "^6.1.0"
       }
     },
     "node_modules/@speclynx/apidom-parser-adapter-yaml-1-2": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-yaml-1-2/-/apidom-parser-adapter-yaml-1-2-4.10.0.tgz",
-      "integrity": "sha512-FBouheDMGfeTd8XqZhN799mBTGD5LoyVZiorSNkcHI1xX8flXx9QhAS9H9d6MWa9YV9rVf72XisBh5NF+2q0OQ==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-parser-adapter-yaml-1-2/-/apidom-parser-adapter-yaml-1-2-4.11.1.tgz",
+      "integrity": "sha512-csFzKGexJqRRR4J49q8+U3LNSX0TsDXzwZhAWCHMEgTPMGHtgFij1chJNNUN50cynKsdoNvswQDEJznPzxsUSw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.10.0",
-        "@speclynx/apidom-datamodel": "4.10.0",
-        "@speclynx/apidom-error": "4.10.0",
+        "@babel/runtime-corejs3": "^7.29.7",
+        "@speclynx/apidom-core": "4.11.1",
+        "@speclynx/apidom-datamodel": "4.11.1",
+        "@speclynx/apidom-error": "4.11.1",
         "ramda": "~0.32.0",
-        "ramda-adjunct": "^6.0.0",
+        "ramda-adjunct": "^6.1.0",
         "unraw": "^3.0.0",
-        "web-tree-sitter": "=0.26.8",
-        "yaml": "^2.8.4"
+        "web-tree-sitter": "=0.26.9",
+        "yaml": "^2.9.0"
       }
     },
     "node_modules/@speclynx/apidom-reference": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-reference/-/apidom-reference-4.10.0.tgz",
-      "integrity": "sha512-UFTwhlkHQkJooT6+BSY97KDTT3ki5EjAQ7hntaVBRW56RB38qS9MSFk4r9PXfFyes9PqtmBARcg34MNaM3SjRQ==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-reference/-/apidom-reference-4.11.1.tgz",
+      "integrity": "sha512-gB7aqSRL2IkzSjFK0KfTWyFdMQILuWLj8p5JLf7XXfTPvHx09CqJkSX1pBGulrn9DqDuOiQO0gMqJecTWo8VPw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-core": "4.10.0",
-        "@speclynx/apidom-datamodel": "4.10.0",
-        "@speclynx/apidom-error": "4.10.0",
-        "@speclynx/apidom-json-pointer": "4.10.0",
-        "@speclynx/apidom-ns-arazzo-1": "4.10.0",
-        "@speclynx/apidom-ns-asyncapi-2": "4.10.0",
-        "@speclynx/apidom-ns-json-schema-2020-12": "4.10.0",
-        "@speclynx/apidom-ns-openapi-2": "4.10.0",
-        "@speclynx/apidom-ns-openapi-3-0": "4.10.0",
-        "@speclynx/apidom-ns-openapi-3-1": "4.10.0",
-        "@speclynx/apidom-ns-overlay-1": "4.10.0",
-        "@speclynx/apidom-parser-adapter-arazzo-json-1": "4.10.0",
-        "@speclynx/apidom-parser-adapter-arazzo-yaml-1": "4.10.0",
-        "@speclynx/apidom-parser-adapter-asyncapi-json-2": "4.10.0",
-        "@speclynx/apidom-parser-adapter-asyncapi-yaml-2": "4.10.0",
-        "@speclynx/apidom-parser-adapter-json": "4.10.0",
-        "@speclynx/apidom-parser-adapter-openapi-json-2": "4.10.0",
-        "@speclynx/apidom-parser-adapter-openapi-json-3-0": "4.10.0",
-        "@speclynx/apidom-parser-adapter-openapi-json-3-1": "4.10.0",
-        "@speclynx/apidom-parser-adapter-openapi-yaml-2": "4.10.0",
-        "@speclynx/apidom-parser-adapter-openapi-yaml-3-0": "4.10.0",
-        "@speclynx/apidom-parser-adapter-openapi-yaml-3-1": "4.10.0",
-        "@speclynx/apidom-parser-adapter-overlay-json-1": "4.10.0",
-        "@speclynx/apidom-parser-adapter-overlay-yaml-1": "4.10.0",
-        "@speclynx/apidom-parser-adapter-yaml-1-2": "4.10.0",
-        "@speclynx/apidom-traverse": "4.10.0",
+        "@babel/runtime-corejs3": "^7.29.7",
+        "@speclynx/apidom-core": "4.11.1",
+        "@speclynx/apidom-datamodel": "4.11.1",
+        "@speclynx/apidom-error": "4.11.1",
+        "@speclynx/apidom-json-pointer": "4.11.1",
+        "@speclynx/apidom-ns-arazzo-1": "4.11.1",
+        "@speclynx/apidom-ns-asyncapi-2": "4.11.1",
+        "@speclynx/apidom-ns-json-schema-2020-12": "4.11.1",
+        "@speclynx/apidom-ns-openapi-2": "4.11.1",
+        "@speclynx/apidom-ns-openapi-3-0": "4.11.1",
+        "@speclynx/apidom-ns-openapi-3-1": "4.11.1",
+        "@speclynx/apidom-ns-overlay-1": "4.11.1",
+        "@speclynx/apidom-parser-adapter-arazzo-json-1": "4.11.1",
+        "@speclynx/apidom-parser-adapter-arazzo-yaml-1": "4.11.1",
+        "@speclynx/apidom-parser-adapter-asyncapi-json-2": "4.11.1",
+        "@speclynx/apidom-parser-adapter-asyncapi-yaml-2": "4.11.1",
+        "@speclynx/apidom-parser-adapter-json": "4.11.1",
+        "@speclynx/apidom-parser-adapter-openapi-json-2": "4.11.1",
+        "@speclynx/apidom-parser-adapter-openapi-json-3-0": "4.11.1",
+        "@speclynx/apidom-parser-adapter-openapi-json-3-1": "4.11.1",
+        "@speclynx/apidom-parser-adapter-openapi-yaml-2": "4.11.1",
+        "@speclynx/apidom-parser-adapter-openapi-yaml-3-0": "4.11.1",
+        "@speclynx/apidom-parser-adapter-openapi-yaml-3-1": "4.11.1",
+        "@speclynx/apidom-parser-adapter-overlay-json-1": "4.11.1",
+        "@speclynx/apidom-parser-adapter-overlay-yaml-1": "4.11.1",
+        "@speclynx/apidom-parser-adapter-yaml-1-2": "4.11.1",
+        "@speclynx/apidom-traverse": "4.11.1",
         "@swaggerexpert/arazzo-runtime-expression": "^2.0.3",
-        "axios": "^1.16.0",
+        "axios": "^1.17.0",
         "picomatch": "^4.0.4",
         "process": "^0.11.10",
         "ramda": "~0.32.0",
-        "ramda-adjunct": "^6.0.0"
+        "ramda-adjunct": "^6.1.0"
       }
     },
     "node_modules/@speclynx/apidom-traverse": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@speclynx/apidom-traverse/-/apidom-traverse-4.10.0.tgz",
-      "integrity": "sha512-xiiVVKOUGrBQ1s/K2GWbdVDRLmXEuv9qhqPb0S0HlBUP+K1srNSqB7oKDLYtVC+EQi0Lft0CYdNxAwwaRxc2xw==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@speclynx/apidom-traverse/-/apidom-traverse-4.11.1.tgz",
+      "integrity": "sha512-FqnAhtBZRdS7LlQnaSKVpPpOAWioGQeH46gj+uSqn7VZHqpEyh0MRDsS7bt87gC+fdpgzb7bvio7XAQXjJ/zgQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "^7.28.4",
-        "@speclynx/apidom-datamodel": "4.10.0",
-        "@speclynx/apidom-error": "4.10.0",
-        "@speclynx/apidom-json-path": "4.10.0",
-        "@speclynx/apidom-json-pointer": "4.10.0",
-        "ramda-adjunct": "^6.0.0"
+        "@babel/runtime-corejs3": "^7.29.7",
+        "@speclynx/apidom-datamodel": "4.11.1",
+        "@speclynx/apidom-error": "4.11.1",
+        "@speclynx/apidom-json-path": "4.11.1",
+        "@speclynx/apidom-json-pointer": "4.11.1",
+        "ramda-adjunct": "^6.1.0"
       }
     },
     "node_modules/@stoplight/better-ajv-errors": {
@@ -1953,6 +1954,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -2138,9 +2140,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
-      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
+      "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
@@ -2409,9 +2411,9 @@
       }
     },
     "node_modules/core-js-pure": {
-      "version": "3.48.0",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.48.0.tgz",
-      "integrity": "sha512-1slJgk89tWC51HQ1AEqG+s2VuwpTRr8ocu4n20QUcH1v9lAN0RXen0Q0AABa/DK1I7RrNWLucplOHMx8hfTGTw==",
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.49.0.tgz",
+      "integrity": "sha512-XM4RFka59xATyJv/cS3O3Kml72hQXUeGRuuTmMYFxwzc9/7C8OYTaIR/Ji+Yt8DXzsFLNhat15cE/JP15HrCgw==",
       "hasInstallScript": true,
       "license": "MIT",
       "funding": {
@@ -3797,6 +3799,7 @@
       "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -4094,6 +4097,7 @@
       "resolved": "https://registry.npmjs.org/mobx/-/mobx-6.15.0.tgz",
       "integrity": "sha512-UczzB+0nnwGotYSgllfARAqWCJ5e/skuV2K/l+Zyck/H6pJIhLXuBnz+6vn2i211o7DtbE78HQtsYEKICHGI+g==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mobx"
@@ -4638,15 +4642,16 @@
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.32.0.tgz",
       "integrity": "sha512-GQWAHhxhxWBWA8oIBr1XahFVjQ9Fic6MK9ikijfd4TZHfE2+urfk+irVlR5VOn48uwMgM+loRRBJd6Yjsbc0zQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ramda"
       }
     },
     "node_modules/ramda-adjunct": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-6.0.0.tgz",
-      "integrity": "sha512-mdGCk0Gj3nQQ7lJ2XfuOFsc3GtfAn5jJWcQ/FuEPvP8E+gaXQ+z+3y/HtKGoYkrOWgE645VCdK54GNvKkXYQlw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-6.1.0.tgz",
+      "integrity": "sha512-G8gZ69zOobM1SFgc9V5Ggy+kFusdPgOQHB60CcxoJWoD6t1DlnCFYeLGhlvyLWiI7AYwPVeMKqamA8Yr2lz66g==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.3"
@@ -4673,6 +4678,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4682,6 +4688,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -4913,6 +4920,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.80.0.tgz",
       "integrity": "sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -5418,6 +5426,7 @@
       "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.4.1.tgz",
       "integrity": "sha512-ADu2dF53esUzzM4I0ewxhxFtsDd6v4V6dNkg3vG0iFKhnt06sJneTZnRvujAosZwW0XD58IKgGMQoqri4wHRqg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emotion/is-prop-valid": "1.4.0",
         "css-to-react-native": "3.2.0",
@@ -5753,9 +5762,9 @@
       "license": "MIT"
     },
     "node_modules/web-tree-sitter": {
-      "version": "0.26.8",
-      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.26.8.tgz",
-      "integrity": "sha512-4sUwi7ZyOrIk5KLgYLkc2A/F0LFMQnBhfb+2Cdl7ik4ePJ6JD+fk4ofI2sA5eGawBKBaK4Vntt7Ww5KcEsay4A==",
+      "version": "0.26.9",
+      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.26.9.tgz",
+      "integrity": "sha512-YJwSHANl6XFgeEjB8nitgj0qZYt5gkIesJ4w2srS2wcLB4GUa4xcOkM0YaMsU6WNR53YVIkDSY7Ej4pf3IXtCA==",
       "license": "MIT"
     },
     "node_modules/webidl-conversions": {
@@ -5999,14 +6008,14 @@
       "name": "@jentic/openapi-validator-speclynx",
       "version": "0.1.0",
       "dependencies": {
-        "@speclynx/apidom-core": "4.10.0",
-        "@speclynx/apidom-datamodel": "4.10.0",
-        "@speclynx/apidom-json-path": "4.10.0",
-        "@speclynx/apidom-json-pointer": "4.10.0",
-        "@speclynx/apidom-ns-openapi-3-0": "4.10.0",
-        "@speclynx/apidom-ns-openapi-3-1": "4.10.0",
-        "@speclynx/apidom-reference": "4.10.0",
-        "@speclynx/apidom-traverse": "4.10.0",
+        "@speclynx/apidom-core": "4.11.1",
+        "@speclynx/apidom-datamodel": "4.11.1",
+        "@speclynx/apidom-json-path": "4.11.1",
+        "@speclynx/apidom-json-pointer": "4.11.1",
+        "@speclynx/apidom-ns-openapi-3-0": "4.11.1",
+        "@speclynx/apidom-ns-openapi-3-1": "4.11.1",
+        "@speclynx/apidom-reference": "4.11.1",
+        "@speclynx/apidom-traverse": "4.11.1",
         "commander": "^14.0.2",
         "vscode-languageserver-types": "^3.17.5"
       },

--- a/packages/jentic-openapi-validator-speclynx/src/jentic/apitools/openapi/validator/backends/speclynx/__init__.py
+++ b/packages/jentic-openapi-validator-speclynx/src/jentic/apitools/openapi/validator/backends/speclynx/__init__.py
@@ -39,7 +39,7 @@ class SpeclynxValidatorBackend(BaseValidatorBackend):
         allowed_base_dir: str | Path | None = None,
         plugins_dir: str | Path | None = None,
         source_map: bool = True,
-        skip_visited: bool = False,
+        skip_visited: Literal["never", "skip", "enter-only"] = "never",
     ):
         """
         Initialize the SpeclynxValidatorBackend.
@@ -70,8 +70,13 @@ class SpeclynxValidatorBackend(BaseValidatorBackend):
                 See resources/plugins/example-plugin.mjs.sample for plugin format.
             source_map: Enable source map tracking in the parser (default: True).
                 When disabled, strict parsing mode is enabled automatically.
-            skip_visited: Skip already-visited elements during plugin traversal (default: False).
-                Enable to prevent exponential tree growth on documents with many $ref cycles.
+            skip_visited: Traversal mode controlling how already-visited elements are handled
+                during plugin traversal (default: "never"). Used to prevent exponential tree
+                growth on documents with many $ref cycles:
+                - "never": never skip; traverse every occurrence (no cycle protection).
+                - "skip": skip already-visited elements entirely (no enter/leave, no descent).
+                - "enter-only": still fire enter/leave for each occurrence of a shared element,
+                  but do not descend into the already-walked subtree.
         """
         self.speclynx_path = speclynx_path
         self.timeout = timeout
@@ -171,8 +176,8 @@ class SpeclynxValidatorBackend(BaseValidatorBackend):
                     args.extend(["--allowed-base-dir", str(self.allowed_base_dir)])
                 if not self.source_map:
                     args.append("--no-source-map")
-                if self.skip_visited:
-                    args.append("--skip-visited")
+                if self.skip_visited != "never":
+                    args.extend(["--skip-visited", self.skip_visited])
 
                 # npx with bundled tarball: pass absolute path so npm doesn't
                 # resolve the bare filename relative to its global prefix.

--- a/packages/jentic-openapi-validator-speclynx/src/jentic/apitools/openapi/validator/backends/speclynx/__init__.py
+++ b/packages/jentic-openapi-validator-speclynx/src/jentic/apitools/openapi/validator/backends/speclynx/__init__.py
@@ -27,6 +27,8 @@ logger = logging.getLogger(__name__)
 
 _TARBALL_NAME = "jentic-openapi-validator-speclynx-0.1.0.tgz"
 
+_SKIP_VISITED_MODES = ("never", "skip", "enter-only")
+
 resources_dir = files("jentic.apitools.openapi.validator.backends.speclynx.resources")
 tarball_file = resources_dir.joinpath(_TARBALL_NAME)
 
@@ -77,7 +79,16 @@ class SpeclynxValidatorBackend(BaseValidatorBackend):
                 - "skip": skip already-visited elements entirely (no enter/leave, no descent).
                 - "enter-only": still fire enter/leave for each occurrence of a shared element,
                   but do not descend into the already-walked subtree.
+
+        Raises:
+            ValueError: If skip_visited is not one of "never", "skip", or "enter-only".
         """
+        if skip_visited not in _SKIP_VISITED_MODES:
+            raise ValueError(
+                f"Invalid skip_visited value {skip_visited!r}; "
+                f"expected one of {_SKIP_VISITED_MODES}"
+            )
+
         self.speclynx_path = speclynx_path
         self.timeout = timeout
         self.allowed_base_dir = allowed_base_dir

--- a/packages/jentic-openapi-validator-speclynx/src/jentic/apitools/openapi/validator/backends/speclynx/resources/package.json
+++ b/packages/jentic-openapi-validator-speclynx/src/jentic/apitools/openapi/validator/backends/speclynx/resources/package.json
@@ -14,13 +14,13 @@
   "dependencies": {
     "commander": "^14.0.2",
     "vscode-languageserver-types": "^3.17.5",
-    "@speclynx/apidom-core": "4.10.0",
-    "@speclynx/apidom-datamodel": "4.10.0",
-    "@speclynx/apidom-json-path": "4.10.0",
-    "@speclynx/apidom-json-pointer": "4.10.0",
-    "@speclynx/apidom-ns-openapi-3-0": "4.10.0",
-    "@speclynx/apidom-ns-openapi-3-1": "4.10.0",
-    "@speclynx/apidom-reference": "4.10.0",
-    "@speclynx/apidom-traverse": "4.10.0"
+    "@speclynx/apidom-core": "4.11.1",
+    "@speclynx/apidom-datamodel": "4.11.1",
+    "@speclynx/apidom-json-path": "4.11.1",
+    "@speclynx/apidom-json-pointer": "4.11.1",
+    "@speclynx/apidom-ns-openapi-3-0": "4.11.1",
+    "@speclynx/apidom-ns-openapi-3-1": "4.11.1",
+    "@speclynx/apidom-reference": "4.11.1",
+    "@speclynx/apidom-traverse": "4.11.1"
   }
 }

--- a/packages/jentic-openapi-validator-speclynx/src/jentic/apitools/openapi/validator/backends/speclynx/resources/speclynx.mjs
+++ b/packages/jentic-openapi-validator-speclynx/src/jentic/apitools/openapi/validator/backends/speclynx/resources/speclynx.mjs
@@ -3,7 +3,7 @@ import {promisify} from 'node:util';
 import {readdir, writeFile} from 'node:fs/promises';
 import path from 'node:path';
 import {pathToFileURL, fileURLToPath} from 'node:url';
-import {Command} from 'commander';
+import {Command, Option} from 'commander';
 import * as vscodeLanguageServerTypes from 'vscode-languageserver-types';
 import {Diagnostic, DiagnosticSeverity, Range} from 'vscode-languageserver-types';
 import * as apidomCore from '@speclynx/apidom-core';
@@ -178,7 +178,7 @@ async function validate(document, cliOptions = {}) {
     // When it doesn't exist (e.g., Swagger 2.0), traverse parseResult so ParseResultElement visitor runs
     const elementToTraverse = parseResult.api ?? parseResult;
     const dispatchRefractorPluginsAsync = promisify(dispatchRefractorPlugins);
-    const traverseOptions = cliOptions.skipVisited ? {skipVisited: true} : {};
+    const traverseOptions = cliOptions.skipVisited ? {skipVisited: cliOptions.skipVisited} : {};
     await dispatchRefractorPluginsAsync(elementToTraverse, plugins, {
         toolboxCreator: createToolbox,
         traverseOptions
@@ -205,7 +205,7 @@ program
     .option('--allowed-base-dir <path>', 'restrict file resolution to this directory')
     .option('--timeout <ms>', 'HTTP timeout in milliseconds', '5000')
     .option('--no-source-map', 'disable source map tracking (enables strict parsing)')
-    .option('--skip-visited', 'enable skipVisited traversal optimization to prevent exponential tree growth on $ref cycles')
+    .addOption(new Option('--skip-visited <mode>', 'skipVisited traversal mode controlling how already-visited elements are handled on $ref cycles to prevent exponential tree growth').choices(['never', 'skip', 'enter-only']))
     .action(async (document, cliOptions) => {
         try {
             const result = await validate(document, cliOptions);

--- a/packages/jentic-openapi-validator-speclynx/tests/test_speclynx_validate.py
+++ b/packages/jentic-openapi-validator-speclynx/tests/test_speclynx_validate.py
@@ -241,6 +241,16 @@ class TestSpeclynxValidatorUnit:
             validator = SpeclynxValidatorBackend(skip_visited=mode)
             assert validator.skip_visited == mode
 
+    def test_initialization_with_invalid_skip_visited_raises(self):
+        """Test SpeclynxValidator rejects invalid skip_visited values eagerly."""
+        # Invalid string mode
+        with pytest.raises(ValueError, match="Invalid skip_visited value"):
+            SpeclynxValidatorBackend(skip_visited="bogus")  # type: ignore[arg-type]
+
+        # Legacy boolean values are no longer accepted
+        with pytest.raises(ValueError, match="Invalid skip_visited value"):
+            SpeclynxValidatorBackend(skip_visited=True)  # type: ignore[arg-type]
+
     def test_initialization_with_custom_speclynx_path(self):
         """Test SpeclynxValidator with custom speclynx_path."""
         validator = SpeclynxValidatorBackend(speclynx_path="/custom/path/to/speclynx")

--- a/packages/jentic-openapi-validator-speclynx/tests/test_speclynx_validate.py
+++ b/packages/jentic-openapi-validator-speclynx/tests/test_speclynx_validate.py
@@ -233,6 +233,13 @@ class TestSpeclynxValidatorUnit:
         assert validator.speclynx_path is None
         assert validator.timeout == 600.0
         assert validator.source_map is True
+        assert validator.skip_visited == "never"
+
+    def test_initialization_with_skip_visited_mode(self):
+        """Test SpeclynxValidator accepts skip_visited traversal modes."""
+        for mode in ("never", "skip", "enter-only"):
+            validator = SpeclynxValidatorBackend(skip_visited=mode)
+            assert validator.skip_visited == mode
 
     def test_initialization_with_custom_speclynx_path(self):
         """Test SpeclynxValidator with custom speclynx_path."""


### PR DESCRIPTION
## Summary

Integrates [SpecLynx ApiDOM v4.11.1](https://github.com/speclynx/apidom/releases/tag/v4.11.1) into the SpecLynx validator backend.

Bumps all `@speclynx/apidom-*` dependencies from `4.10.0` to `4.11.1`.

## `skipVisited` is now an enum

apidom 4.11.0 changed the traverse `skipVisited` option from a boolean into a string enum (`'never' | 'skip' | 'enter-only'`). The new `enter-only` mode fires enter/leave on each occurrence of a shared node while still not re-descending into the already-walked subtree — letting visitors observe every occurrence of a shared element without combinatorial explosion on `$ref` cycles.

This PR aligns the backend with the new API:

- **`speclynx.mjs`**: `--skip-visited` now takes a `<mode>` value constrained to the three valid choices (`never`, `skip`, `enter-only`) and passes it straight through to `traverseOptions`.
- **`SpeclynxValidatorBackend.skip_visited`**: now `Literal["never", "skip", "enter-only"]` (default `"never"`), replacing the previous `bool` where `False`/`True` mapped to `never`/`skip`. The flag is only forwarded to the CLI when not the default `"never"`.

## Test plan

- [x] `uv run --package jentic-openapi-validator-speclynx pytest` — 27 passed (includes integration tests that npx-install the repacked tarball pulling in apidom 4.11.1)
- [x] `uv run poe lint`
- [x] `uv run poe typecheck`
- [x] Added a unit test covering the `skip_visited` default and the three accepted modes